### PR TITLE
Show link to docs preview

### DIFF
--- a/.github/workflows/Docs.yml
+++ b/.github/workflows/Docs.yml
@@ -18,6 +18,7 @@ jobs:
   docs:
     permissions:
       contents: write
+      statuses: write
     name: Documentation
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
In https://github.com/devmotion/ReliabilityDiagrams.jl/pull/37 I noticed that additional permissions are required since otherwise the Documenter is not allowed to set the deploy status with the link to the preview of the docs.