### PR TITLE
Create prototype Rao-Blackwellised Particle Filter

### DIFF
--- a/examples/rao-blackwellised-particle-filter/Project.toml
+++ b/examples/rao-blackwellised-particle-filter/Project.toml
@@ -1,0 +1,11 @@
+[deps]
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+DynamicIterators = "6c76993d-992e-5bf1-9e63-34920a5a5a38"
+GaussianDistributions = "43dcc890-d446-5863-8d1a-14597580bb8d"
+Kalman = "d59c0ba6-2ef2-5409-8dc5-1fd9a2b46832"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
+SSMProblems = "26aad666-b158-4e64-9d35-0e672562fa48"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"

--- a/examples/rao-blackwellised-particle-filter/demo.jl
+++ b/examples/rao-blackwellised-particle-filter/demo.jl
@@ -1,0 +1,122 @@
+"""
+A Rao-Blackwellised particle filter for conditionally linear Gaussian state space models.
+
+Comments:
+- This specific implementation suffers from duplication of the full model dynamics
+  between the conditioning and conditional model. This would not occur for a general
+  model so is something that needs fixing urgently.
+"""
+
+using Distributions
+using DynamicIterators
+using GaussianDistributions
+using Kalman
+using LinearAlgebra
+using LogExpFunctions
+using Plots
+using Random
+using StatsBase
+using ProgressMeter
+
+using Revise
+
+includet("inference.jl")
+includet("model.jl")
+
+# Parameters
+SEED = 1235
+T = 20
+N_PARTICLES = 10^5
+
+# Model definition
+x0 = [0.01, -0.01]
+P0 = Matrix(0.1I, 2, 2)
+Φ = [
+    -0.2 0.0
+    0.5 -0.3
+]
+b = zeros(2)
+Q = [
+    0.3 0.0
+    0.0 0.2
+]
+H = [0.0 1.0]
+R = Matrix(0.1I, 1, 1)
+D1 = 1
+D2 = 1
+
+######################
+#### GROUND TRUTH ####
+######################
+
+# Model definition using Kalman.jl
+E = LinearEvolution(Φ, Gaussian(b, Q))
+Obs = LinearObservationModel(H, R)
+M = LinearStateSpaceModel(E, Obs)
+
+O = LinearObservation(LinearEvolution(Φ, Gaussian(b, Q)), H, R)
+
+# Simulate from model
+Random.seed!(SEED)
+G0 = Gaussian(x0, P0)
+x = rand(StateObs(G0, M.obs))
+X = trace(DynamicIterators.Sampled(M), 1 => x, endtime(T))
+Y = collect(t => y for (t, (x, y)) in pairs(X))
+ys = stack(collect(y for (t, (x, y)) in pairs(X)))
+
+# Ground truth smoothing
+Xf, ll = kalmanfilter(M, 1 => G0, Y)
+Xs, ll = rts_smoother(M, 1 => G0, Y)
+
+###########################################
+#### RAO-BLACKWELLISED PARTICLE FILTER ####
+###########################################
+
+m1 = NonAnalyticLinearGaussianSSM(D1, D2, x0, P0, Φ, b, Q, H, R)
+m2 = FullyLinearGaussianSubsetSSM(D1, D2, x0, P0, Φ, b, Q, H, R)
+model = RaoBlackwellisedSSM(m1, m2)
+
+rng = MersenneTwister(SEED)
+particles = filter(rng, model, ys, N_PARTICLES);
+
+####################
+#### VALIDATION ####
+####################
+
+# Compare inner means
+kalman_filter_means = map(G -> G.μ[2], Xf.x)
+particle_filter_means = Vector{Float64}(undef, T)
+for t in 1:T
+    weights = softmax(map(p -> p.log_w, particles[:, t]))
+    particle_filter_means[t] = sum(weights .* map(p -> p.μ[], particles[:, t]))
+end
+p1 = plot(
+    collect(1:T),
+    kalman_filter_means;
+    label="Kalman filter",
+    xlabel="Time",
+    ylabel="Inner state",
+    legend=:bottomleft,
+    lw=3,
+)
+plot!(p1, collect(1:T), particle_filter_means; label="Particle filter", s=:dash, lw=3)
+
+# Compare filtered outer means
+kalman_filter_means = map(G -> first(G.μ), Xf.x)
+particle_filter_means = Vector{Float64}(undef, T)
+for t in 1:T
+    weights = softmax(map(p -> p.log_w, particles[:, t]))
+    particle_filter_means[t] = sum(weights .* map(p -> p.x[], particles[:, t]))
+end
+p2 = plot(
+    collect(1:T),
+    kalman_filter_means;
+    label="Kalman filter",
+    xlabel="Time",
+    ylabel="Outer state",
+    legend=:bottomleft,
+    lw=3,
+)
+p2 = plot!(collect(1:T), particle_filter_means; label="Particle filter", s=:dash, lw=3)
+
+plot(p1, p2; layout=(2, 1), size=(800, 600))

--- a/examples/rao-blackwellised-particle-filter/inference.jl
+++ b/examples/rao-blackwellised-particle-filter/inference.jl
@@ -1,0 +1,77 @@
+include("model.jl")
+
+# TODO: rewrite using Gaussian
+struct RaoBlackwellisedParticle
+    x::Vector{Float64}
+    μ::Vector{Float64}
+    Σ::Matrix{Float64}
+    log_w::Float64
+    parent_idx::Int64
+end
+
+function filter(
+    rng::AbstractRNG, model::RaoBlackwellisedSSM, ys::Matrix{Float64}, n_particles::Int
+)
+    T = size(ys, 2)
+    m1, m2 = model.conditioning_model, model.conditional_model
+
+    # Create container for particle histories
+    particles = Matrix{RaoBlackwellisedParticle}(undef, n_particles, T)
+
+    # Filter and create initial state
+    z_sub = m2.z[(m2.D1 + 1):end]
+    P_sub = m2.P[(m2.D1 + 1):end, (m2.D1 + 1):end]
+    H_sub = m2.H[:, (m2.D1 + 1):end]
+
+    # TODO: replace with solve
+    K = P_sub * H_sub' * inv(H_sub * P_sub * H_sub' + m2.R)
+    μ = z_sub + K * (ys[:, 1] - H_sub * z_sub)
+    Σ = (I - K * H_sub) * P_sub
+
+    # Reweight
+    μ_y = H_sub * z_sub
+    Σ_y = H_sub * P_sub * H_sub' + m2.R
+    log_w = logpdf(MvNormal(μ_y, Σ_y), ys[:, 1])
+
+    for i in 1:n_particles
+        x = transition!!(rng, m1)
+        particles[i, 1] = RaoBlackwellisedParticle(x, μ, Σ, -log(n_particles) + log_w, -1)
+    end
+
+    # Forward pass
+    ProgressMeter.@showprogress for t in 2:T
+
+        # Resample particles
+        weights = softmax(map(p -> p.log_w, particles[:, t - 1]))
+        parent_idxs = sample(1:n_particles, Weights(weights), n_particles)
+
+        # Step filter
+        for j in 1:n_particles
+            i = parent_idxs[j]
+            # Transition outer state
+            x = transition!!(rng, m1, particles[i, t - 1].x)
+
+            # Transition inner state
+            Q_sub = m2.Q[(m2.D1 + 1):end, (m2.D1 + 1):end]
+            A = m2.Φ[(m2.D1 + 1):end, (m2.D1 + 1):end]
+            b = m2.Φ[(D1 + 1):end, 1:D1] * particles[i, t - 1].x + m2.b[(m2.D1 + 1):end]
+            μ_pred = A * particles[i, t - 1].μ + b
+            Σ_pred = A * particles[i, t - 1].Σ * A' + Q_sub
+
+            # Correct state – assuming observing noisy outer state
+            K = Σ_pred * H_sub' * inv(H_sub * Σ_pred * H_sub' + m2.R)
+            μ = μ_pred + K * (ys[:, t] - H_sub * μ_pred)
+            Σ = (I - K * H_sub) * Σ_pred
+
+            # Update particle weight
+            μ_y = H_sub * μ_pred
+            Σ_y = H_sub * Σ_pred * H_sub' + m2.R
+            log_w = -log(n_particles) + logpdf(MvNormal(μ_y, Σ_y), ys[:, t])
+
+            # Create new particle
+            particles[j, t] = RaoBlackwellisedParticle(x, μ, Σ, log_w, i)
+        end
+    end
+
+    return particles
+end

--- a/examples/rao-blackwellised-particle-filter/model.jl
+++ b/examples/rao-blackwellised-particle-filter/model.jl
@@ -1,0 +1,131 @@
+using SSMProblems
+
+abstract type ConditionallyLinearGaussianSSM <: AbstractStateSpaceModel end
+
+struct RaoBlackwellisedSSM
+    conditioning_model::AbstractStateSpaceModel
+    conditional_model::ConditionallyLinearGaussianSSM
+end
+
+###########################
+#### CONDITIONAL MODEL ####
+###########################
+
+struct FullyLinearGaussianSubsetSSM <: ConditionallyLinearGaussianSSM
+    """
+        Consider a state space model with linear dynamics and Gaussian noise.
+        The model is defined by the following equations:
+        x[0] = z + ϵ,                 ϵ    ∼ N(0, P)
+        x[k] = Φx[k-1] + b + w[k],    w[k] ∼ N(0, Q)
+        y[k] = Hx[k] + v[k],          v[k] ∼ N(0, R)
+
+        This SSM represents a subset of the state space model where some of the
+        dimensions are conditionally independent given the rest.
+
+        There are assumed to be `D1` conditioning dimensions, and that these
+        are the first `D1` dimensions of the state vector.
+
+        It is therefore required that the:
+        - first `D1` columns of `H` are zero and that
+        - upper-right `D1`x`D2` block of `Φ` is zero
+        - `P`, `Q` are block diagonal
+    """
+    D1::Int  # Number of conditioning dimensions
+    D2::Int  # Number of conditional dimensions
+    z::Vector{Float64}
+    P::Matrix{Float64}
+    Φ::Matrix{Float64}
+    b::Vector{Float64}
+    Q::Matrix{Float64}
+    H::Matrix{Float64}
+    R::Matrix{Float64}
+end
+
+function transition!!(rng::AbstractRNG, model::FullyLinearGaussianSubsetSSM)
+    D1 = model.D1
+    return Gaussian(model.z[(D1 + 1):end], model.P[(D1 + 1):end, (D1 + 1):end])
+end
+
+function transition!!(
+    rng::AbstractRNG,
+    model::FullyLinearGaussianSubsetSSM,
+    state::Gaussian,
+    control::Vector{Float64},
+)
+    # Subset variables
+    D1 = model.D1
+    Φ_sub = model.Φ[(D1 + 1):end, (D1 + 1):end]
+    b_sub = model.b[(D1 + 1):end]
+    Q_sub = model.Q[(D1 + 1):end, (D1 + 1):end]
+
+    # Conditioning (use previous conditioning state as a control variable)
+    b_cond = model.Φ[(D1 + 1):end, 1:D1] * control
+
+    # Transition
+    μ = Φ_sub * state.μ + b_sub + b_cond
+    Σ = Φ_sub * state.Σ * Φ_sub + Q_sub
+    return Gaussian(μ, Σ)
+end
+
+function observation!!(
+    rng::AbstractRNG, model::FullyLinearGaussianSubsetSSM, state::Gaussian
+)
+    return Gaussian(model.H * state.μ, model.R)
+end
+
+############################
+#### CONDITIONING MODEL ####
+############################
+
+struct NonAnalyticLinearGaussianSSM <: AbstractStateSpaceModel
+    """
+        Consider a state space model with linear dynamics and Gaussian noise.
+        The model is defined by the following equations:
+        x[0] = z + ϵ,                 ϵ    ∼ N(0, P)
+        x[k] = Φx[k-1] + b + w[k],    w[k] ∼ N(0, Q)
+        y[k] = Hx[k] + v[k],          v[k] ∼ N(0, R)
+
+        This SSM represents a subset of the state space model from which another
+        SSM can be conditioned upon.
+
+        There are assumed to be `D1` conditioning dimensions, and that these
+        are the first `D1` dimensions of the state vector.
+
+        It is therefore required that the:
+        - first `D1` columns of `H` are zero and that
+        - upper-right `D1`x`D2` block of `Φ` is zero
+        - `P`, `Q` are block diagonal
+
+        Although inference on this model can be performed analytically using the 
+        Kalman filter, it is treated as a non-analytic model in this case for the
+        purpose of testing.
+    """
+    D1::Int  # Number of conditioning dimensions
+    D2::Int  # Number of conditional dimensions
+    z::Vector{Float64}
+    P::Matrix{Float64}
+    Φ::Matrix{Float64}
+    b::Vector{Float64}
+    Q::Matrix{Float64}
+    H::Matrix{Float64}
+    R::Matrix{Float64}
+end
+
+function transition!!(rng::AbstractRNG, model::NonAnalyticLinearGaussianSSM)
+    D1 = model.D1
+    return rand(Gaussian(model.z[1:D1], model.P[1:D1, 1:D1]))
+end
+
+function transition!!(
+    rng::AbstractRNG, model::NonAnalyticLinearGaussianSSM, state::Vector{Float64}
+)
+    D1 = model.D1
+    Φ_sub = model.Φ[1:D1, 1:D1]
+    b_sub = model.b[1:D1]
+    Q_sub = model.Q[1:D1, 1:D1]
+
+    return rand(Gaussian(Φ_sub * state + b_sub, Q_sub))
+end
+
+# NOTE: we do not need to define the emission_logdensity since the observations only
+# depend on the conditioning state through the conditional variables


### PR DESCRIPTION
This PR introduces a prototype for Rao-Blackwellised particle filtering following the SSMProblems.jl interface.

The implementation is verified using a 2D linear Gaussian SSM with ground truth filtering from Kalman.jl and compared to the RBPF where we use a particle filter for the first hidden state.

As expected, the inner (conditionally Gaussian) state is perfectly filtered whilst the outer (particle filter) filtered state is close  to the ground truth filtered mean.

![Comparison](https://github.com/TuringLang/SSMProblems.jl/assets/38204689/1de88b30-2c8e-431e-a7d1-4bd9ecaa9459)

The outer/inner (a.k.a conditioning/conditional, non-analytic/analytic) dynamics are both represented as their own SSM.

The outer model has no `emission_logprobability` since the observations only depend on the hidden state in a Rao-Blackwellised model. 

The inner model is conditioned on the outer model through the introduction of control variables.

```
function transition!!(
    rng::AbstractRNG,
    model::FullyLinearGaussianSubsetSSM,
    state::Gaussian,
    step::Int
    control::Vector{Float64},
)
```

This is a common inclusion in SSMs so we would have needed to add this to the interface anyway.

I don't think this interface is _ideal_—it's a bit strange that the outer dynamics are defined through a SSM despite having no observations—but it's not too bad at all.
