### PR TITLE
Particle filter example

### DIFF
--- a/examples/particle-filter/Project.toml
+++ b/examples/particle-filter/Project.toml
@@ -1,0 +1,8 @@
+[deps]
+AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+Metal = "dde4c033-4e86-420c-a63e-0dd931031962"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+SSMProblems = "26aad666-b158-4e64-9d35-0e672562fa48"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"

--- a/examples/particle-filter/Project.toml
+++ b/examples/particle-filter/Project.toml
@@ -1,6 +1,9 @@
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
+AdvancedPS = "576499cb-2369-40b2-a588-c64705576edc"
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+GPUArrays = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
 Metal = "dde4c033-4e86-420c-a63e-0dd931031962"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 SSMProblems = "26aad666-b158-4e64-9d35-0e672562fa48"

--- a/examples/particle-filter/script.jl
+++ b/examples/particle-filter/script.jl
@@ -1,0 +1,115 @@
+# # Partilce Filter with adaptive resampling
+using StatsBase
+using AbstractMCMC
+using Random
+using SSMProblems
+using Distributions
+using Plots
+using StatsFuns
+
+# Particle Filter 
+ess(weights) = inv(sum(abs2, weights))
+get_weights(logweights::T) where {T<:AbstractVector{<:Real}} = StatsFuns.softmax(logweights)
+
+function systematic_resampling(
+    rng::AbstractRNG, weights::AbstractVector{<:Real}, n::Integer=length(weights)
+)
+    return rand(rng, Distributions.Categorical(weights), n)
+end
+
+function sweep!(
+    rng::AbstractRNG,
+    model::AbstractStateSpaceModel,
+    particles,
+    observations::AbstractArray,
+    resampling=systematic_resampling,
+    threshold=0.5,
+)
+    N = length(particles[:, 1])
+    logweights = zeros(N)
+
+    for (timestep, observation) in enumerate(observations)
+        weights = get_weights(logweights)
+        if ess(weights) <= threshold * N
+            idx = resampling(rng, weights)
+            particles = particles[idx, timestep]
+            fill!(logweights, 0)
+        end
+
+        latent_state = zeros(N)
+        for i in eachindex(particles[:, timestep])
+            latent_state[i]= SSMProblems.simulate(rng, model.dyn, timestep, particles[i, timestep], nothing)
+            logweights[i] += SSMProblems.logdensity(
+                model.obs, timestep, particles[i, timestep], observation, nothing
+            )
+        end
+        particles[:, timestep] = latent_state
+    end
+
+    idx = resampling(rng, get_weights(logweights))
+    return particles[idx, end]
+end
+
+# Turing style sample method
+function StatsBase.sample(
+    rng::AbstractRNG,
+    model::AbstractStateSpaceModel,
+    n::Int,
+    observations::AbstractVector;
+    resampling=systematic_resampling,
+    threshold=0.5,
+)
+    T = length(observations)
+    particles = zeros(Float64, n, T)
+    vec = map(1:N) do i
+        state = SSMProblems.simulate(rng, model.dyn, nothing)
+    end
+    particles[:, 1] = collect(vec)
+    samples = sweep!(rng, model, particles, observations, resampling, threshold)
+    return particles
+end
+
+# Inference code
+struct LinearGaussianLatentDynamics{T<:Real} <: LatentDynamics
+    σ::T
+end
+
+struct LinearGaussianObservationProcess{T<:Real} <: ObservationProcess
+    σ::T
+end
+
+const LinearGaussianSSM{T} = StateSpaceModel{
+    <:LinearGaussianLatentDynamics{T},<:LinearGaussianObservationProcess{T}
+};
+
+function SSMProblems.distribution(dyn::LinearGaussianLatentDynamics, extra::Nothing)
+    return Normal(0, dyn.σ)
+end
+
+function SSMProblems.distribution(dyn::LinearGaussianLatentDynamics, step::Int, state::Real, extra::Nothing)
+    return Normal(state, dyn.σ)
+end
+
+function SSMProblems.distribution(obs::LinearGaussianObservationProcess, step::Int, state::Real, extra::Nothing)
+    return Normal(state, dyn.σ)
+end
+
+
+# Simulation
+T = 150
+seed = 1
+N = 500
+rng = MersenneTwister(seed)
+
+dyn = LinearGaussianLatentDynamics(0.2)
+obs = LinearGaussianObservationProcess(0.7)
+model = StateSpaceModel(dyn, obs)
+xs, ys = sample(rng, model, T)
+
+particles = sample(rng, model, N, ys)
+
+plot(xs; label="True state", linewidth=2)
+plot(ys; label="True state", linewidth=2)
+gui()
+
+a = 1


### PR DESCRIPTION
Small example of a particle filter using the new API. Since Metal.jl doesn't really support `rand()` / `Distributions`, it's hard to make this more complex. 

Discussed here https://github.com/TuringLang/SSMProblems.jl/issues/43 