### PR TITLE
Alignment of obs/dyn time steps and refactored forward simulation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,14 +1,21 @@
 name = "SSMProblems"
 uuid = "26aad666-b158-4e64-9d35-0e672562fa48"
 authors = ["FredericWantiez <frederic.wantiez@gmail.com>"]
-version = "0.2"
+version = "0.2.0"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 AbstractMCMC = "5"
 Distributions = "0.25"
 julia = "1.6"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SSMProblems"
 uuid = "26aad666-b158-4e64-9d35-0e672562fa48"
 authors = ["FredericWantiez <frederic.wantiez@gmail.com>"]
-version = "0.2.0"
+version = "0.3.0"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/examples/kalman-filter/script.jl
+++ b/examples/kalman-filter/script.jl
@@ -25,7 +25,7 @@ using SSMProblems
 #
 # We store all of these paramaters in a struct.
 
-struct LinearGaussianLatentDynamics{T<:Real} <: LatentDynamics
+struct LinearGaussianLatentDynamics{T<:Real} <: LatentDynamics{Vector{T}}
     z::Vector{T}
     P::Matrix{T}
     Φ::Matrix{T}
@@ -38,7 +38,7 @@ end
 # y[k] = Hx[k] + v[k],          v[k] ∼ N(0, R)
 # ```
 
-struct LinearGaussianObservationProcess{T<:Real} <: ObservationProcess
+struct LinearGaussianObservationProcess{T<:Real} <: ObservationProcess{Vector{T},Vector{T}}
     H::Matrix{T}
     R::Matrix{T}
 end
@@ -53,22 +53,16 @@ end
 # be preferred in this linear Gaussian case, it may be of interest to compare the sampling
 # performance with a general particle filter.
 
-function SSMProblems.distribution(model::LinearGaussianLatentDynamics, extra::Nothing)
+function SSMProblems.distribution(model::LinearGaussianLatentDynamics)
     return MvNormal(model.z, model.P)
 end
 function SSMProblems.distribution(
-    model::LinearGaussianLatentDynamics{T},
-    step::Int,
-    state::AbstractVector{T},
-    extra::Nothing,
+    model::LinearGaussianLatentDynamics{T}, step::Int, prev_state::Vector{T}, extra::Nothing
 ) where {T}
-    return MvNormal(model.Φ * state + model.b, model.Q)
+    return MvNormal(model.Φ * prev_state + model.b, model.Q)
 end
 function SSMProblems.distribution(
-    model::LinearGaussianObservationProcess{T},
-    step::Int,
-    state::AbstractVector{T},
-    extra::Nothing,
+    model::LinearGaussianObservationProcess{T}, step::Int, state::Vector{T}, extra::Nothing
 ) where {T}
     return MvNormal(model.H * state, model.R)
 end

--- a/examples/kalman-filter/script.jl
+++ b/examples/kalman-filter/script.jl
@@ -38,7 +38,7 @@ end
 # y[k] = Hx[k] + v[k],          v[k] ∼ N(0, R)
 # ```
 
-struct LinearGaussianObservationProcess{T<:Real} <: ObservationProcess{Vector{T},Vector{T}}
+struct LinearGaussianObservationProcess{T<:Real} <: ObservationProcess{Vector{T}}
     H::Matrix{T}
     R::Matrix{T}
 end
@@ -53,7 +53,7 @@ end
 # be preferred in this linear Gaussian case, it may be of interest to compare the sampling
 # performance with a general particle filter.
 
-function SSMProblems.distribution(model::LinearGaussianLatentDynamics)
+function SSMProblems.distribution(model::LinearGaussianLatentDynamics, extra::Nothing)
     return MvNormal(model.z, model.P)
 end
 function SSMProblems.distribution(
@@ -90,6 +90,7 @@ function AbstractMCMC.sample(
     model::LinearGaussianSSM{U},
     ::KalmanFilter,
     observations::AbstractVector,
+    extra0,
     extras::AbstractVector,
 ) where {U}
     T = length(observations)
@@ -99,35 +100,40 @@ function AbstractMCMC.sample(
     @unpack z, P, Φ, b, Q = model.dyn  ## Extract parameters
     @unpack H, R = model.obs
 
+    # Initialise the filter
+    x = z
+    P = P
+
     for t in 1:T
-        x_pred, P_pred = if t == 1
-            z, P
-        else
-            Φ * x_filts[t - 1] + b, Φ * P_filts[t - 1] * Φ' + Q  ## Prediction step
-        end
+        # Prediction step
+        x = Φ * x + b
+        P = Φ * P * Φ' + Q
 
-        y = observations[t]   ## Update step
-        K = P_pred * H' / (H * P_pred * H' + R)
-        x_filt = x_pred + K * (y - H * x_pred)
-        P_filt = P_pred - K * H * P_pred
+        # Update step
+        y = observations[t]
+        K = P * H' / (H * P * H' + R)
+        x = x + K * (y - H * x)
+        P = P - K * H * P
 
-        x_filts[t] = x_filt
-        P_filts[t] = P_filt
+        x_filts[t] = x
+        P_filts[t] = P
     end
 
     return x_filts, P_filts
 end
 
 # In this specific case, however, since our model is homogenous, we do not expect to have
-# any extras passed in. For convenience, we create a method without the `extras` argument
-# which then replaces them with a vector of `nothing`s. This pattern is not specific to
-# linear Gaussian models or Kalman filters so we define it with general types.
+# any extras passed in. For convenience, we create a method without the `extra0` and
+# `extras` argument which then replaces them with `nothing` and a vector of `nothing`s,
+# respectively. This pattern is not specific to linear Gaussian models or Kalman filters so
+# we define it with general types.
 
 function AbstractMCMC.sample(
     model::StateSpaceModel, algorithm, observations::AbstractVector
 )
+    extra0 = nothing
     extras = fill(nothing, length(observations))
-    return sample(model, algorithm, observations, extras)
+    return sample(model, algorithm, observations, extra0, extras)
 end
 
 # ## Simulation and Filtering
@@ -156,7 +162,7 @@ model = StateSpaceModel(dyn, obs);
 # functions we defined above.
 
 rng = MersenneTwister(SEED);
-xs, ys = sample(rng, model, T);
+x0, xs, ys = sample(rng, model, T);
 
 # We can then run the Kalman filter and plot the filtering results against the ground truth.
 

--- a/examples/kalman-filter/script.jl
+++ b/examples/kalman-filter/script.jl
@@ -100,16 +100,16 @@ function AbstractMCMC.sample(
     @unpack z, P, Φ, b, Q = model.dyn  ## Extract parameters
     @unpack H, R = model.obs
 
-    # Initialise the filter
+    ## Initialise the filter
     x = z
     P = P
 
     for t in 1:T
-        # Prediction step
+        ## Prediction step
         x = Φ * x + b
         P = Φ * P * Φ' + Q
 
-        # Update step
+        ## Update step
         y = observations[t]
         K = P * H' / (H * P * H' + R)
         x = x + K * (y - H * x)

--- a/src/SSMProblems.jl
+++ b/src/SSMProblems.jl
@@ -20,6 +20,9 @@ export LatentDynamics, ObservationProcess, AbstractStateSpaceModel, StateSpaceMo
 
     Alternatively, you may specify methods for the function `distribution` which will be
     used to define the above methods.
+
+    # Parameters
+    - `T`: The type of the state of the latent dynamics.
 """
 abstract type LatentDynamics{T} end
 
@@ -39,6 +42,10 @@ Base.eltype(::Type{<:LatentDynamics{T}}) where {T} = T
     
     Alternatively, you may specify a method for `distribution`, which will be used to define
     both of the above methods.
+
+    # Parameters
+    - `T`: The type of the state of the latent dynamics.
+    - `U`: The type of the observation.
 """
 abstract type ObservationProcess{T,U} end
 

--- a/src/SSMProblems.jl
+++ b/src/SSMProblems.jl
@@ -4,6 +4,7 @@ A unified interface to define state space models in the context of particle MCMC
 module SSMProblems
 
 using AbstractMCMC: AbstractMCMC
+import Base: eltype
 import Random: AbstractRNG, default_rng
 import Distributions: logpdf
 
@@ -20,7 +21,14 @@ export LatentDynamics, ObservationProcess, AbstractStateSpaceModel, StateSpaceMo
     Alternatively, you may specify methods for the function `distribution` which will be
     used to define the above methods.
 """
-abstract type LatentDynamics end
+abstract type LatentDynamics{T} end
+
+"""
+    eltype(dyn::LatentDynamics)
+
+    Return the type of the state of the latent dynamics.
+"""
+Base.eltype(::Type{<:LatentDynamics{T}}) where {T} = T
 
 """
     Observation process of a state space model.
@@ -32,10 +40,20 @@ abstract type LatentDynamics end
     Alternatively, you may specify a method for `distribution`, which will be used to define
     both of the above methods.
 """
-abstract type ObservationProcess end
+abstract type ObservationProcess{T,U} end
 
 """
-    distribution(dyn::LatentDynamics, extra)
+    eltype(obs::ObservationProcess)
+
+    Return a pair of types for the state and observation of the observation process.
+
+    The first type is the type of the state of the latent dynamics, and the second type is
+    the type of the observation.
+"""
+Base.eltype(::Type{<:ObservationProcess{T,U}}) where {T,U} = (T, U)
+
+"""
+    distribution(dyn::LatentDynamics)
 
 Return the initialisation distribution for the latent dynamics.
 
@@ -48,8 +66,8 @@ See also [`LatentDynamics`](@ref).
 # Returns
 - `Distributions.Distribution`: The distribution of the initial state.
 """
-function distribution(dyn::LatentDynamics, extra)
-    throw(MethodError(distribution, (dyn, extra)))
+function distribution(dyn::LatentDynamics)
+    throw(MethodError(distribution, (dyn)))
 end
 
 """
@@ -89,7 +107,7 @@ function distribution(obs::ObservationProcess, step::Integer, state, extra)
 end
 
 """
-    simulate([rng::AbstractRNG], dyn::LatentDynamics, extra)
+    simulate([rng::AbstractRNG], dyn::LatentDynamics)
 
     Simulate an initial state for the latent dynamics.
 
@@ -101,11 +119,11 @@ end
 
     See also [`LatentDynamics`](@ref).
 """
-function simulate(rng::AbstractRNG, dyn::LatentDynamics, extra)
-    return rand(rng, distribution(dyn, extra))
+function simulate(rng::AbstractRNG, dyn::LatentDynamics)
+    return rand(rng, distribution(dyn))
 end
-function simulate(dyn::LatentDynamics, extra)
-    return simulate(default_rng(), dyn, extra)
+function simulate(dyn::LatentDynamics)
+    return simulate(default_rng(), dyn)
 end
 
 """
@@ -149,7 +167,7 @@ function simulate(obs::ObservationProcess, step::Integer, state, extra)
 end
 
 """
-    logdensity(dyn::LatentDynamics, new_state, extra)
+    logdensity(dyn::LatentDynamics, new_state)
 
 Compute the log-density of an initial state for the latent dynamics.
 
@@ -161,8 +179,8 @@ corresponding `distribution()` method.
 
 See also [`LatentDynamics`](@ref).
 """
-function logdensity(dyn::LatentDynamics, new_state, extra)
-    return logpdf(distribution(dyn, extra), new_state)
+function logdensity(dyn::LatentDynamics, new_state)
+    return logpdf(distribution(dyn), new_state)
 end
 
 """
@@ -224,7 +242,25 @@ abstract type AbstractStateSpaceModel <: AbstractMCMC.AbstractModel end
 struct StateSpaceModel{LD<:LatentDynamics,OP<:ObservationProcess} <: AbstractStateSpaceModel
     dyn::LD
     obs::OP
+    function StateSpaceModel(dyn::LD, obs::OP) where {LD,OP}
+        # Check state types match
+        if eltype(dyn) != eltype(obs)[1]
+            throw(ArgumentError("State types of `dyn` and `obs` must match"))
+        end
+        return new{LD,OP}(dyn, obs)
+    end
 end
+
+"""
+    eltype(model::StateSpaceModel)
+
+    Return a pair of types for the state and observation of the state space model.
+
+    The first type is the type of the state of the latent dynamics, and the second type is
+    the type of the observation. This is equivalent to calling `eltype` on the observation
+    process.
+"""
+Base.eltype(::Type{<:StateSpaceModel{LD,OP}}) where {LD,OP} = eltype(OP)
 
 include("utils/forward_simulation.jl")
 

--- a/src/SSMProblems.jl
+++ b/src/SSMProblems.jl
@@ -47,7 +47,7 @@ Base.eltype(::Type{<:LatentDynamics{T}}) where {T} = T
     - `T`: The type of the state of the latent dynamics.
     - `U`: The type of the observation.
 """
-abstract type ObservationProcess{T,U} end
+abstract type ObservationProcess{T} end
 
 """
     eltype(obs::ObservationProcess)
@@ -57,10 +57,10 @@ abstract type ObservationProcess{T,U} end
     The first type is the type of the state of the latent dynamics, and the second type is
     the type of the observation.
 """
-Base.eltype(::Type{<:ObservationProcess{T,U}}) where {T,U} = (T, U)
+Base.eltype(::Type{<:ObservationProcess{T}}) where {T} = T
 
 """
-    distribution(dyn::LatentDynamics)
+    distribution(dyn::LatentDynamics, extra)
 
 Return the initialisation distribution for the latent dynamics.
 
@@ -73,7 +73,7 @@ See also [`LatentDynamics`](@ref).
 # Returns
 - `Distributions.Distribution`: The distribution of the initial state.
 """
-function distribution(dyn::LatentDynamics)
+function distribution(dyn::LatentDynamics, extra)
     throw(MethodError(distribution, (dyn)))
 end
 
@@ -126,12 +126,10 @@ end
 
     See also [`LatentDynamics`](@ref).
 """
-function simulate(rng::AbstractRNG, dyn::LatentDynamics)
-    return rand(rng, distribution(dyn))
+function simulate(rng::AbstractRNG, dyn::LatentDynamics, extra)
+    return rand(rng, distribution(dyn, extra))
 end
-function simulate(dyn::LatentDynamics)
-    return simulate(default_rng(), dyn)
-end
+simulate(dyn::LatentDynamics, extra) = simulate(default_rng(), dyn, extra)
 
 """
     simulate([rng::AbstractRNG], dyn::LatentDynamics, step::Integer, prev_state, extra)
@@ -186,8 +184,8 @@ corresponding `distribution()` method.
 
 See also [`LatentDynamics`](@ref).
 """
-function logdensity(dyn::LatentDynamics, new_state)
-    return logpdf(distribution(dyn), new_state)
+function logdensity(dyn::LatentDynamics, new_state, extra)
+    return logpdf(distribution(dyn, extra), new_state)
 end
 
 """
@@ -249,13 +247,6 @@ abstract type AbstractStateSpaceModel <: AbstractMCMC.AbstractModel end
 struct StateSpaceModel{LD<:LatentDynamics,OP<:ObservationProcess} <: AbstractStateSpaceModel
     dyn::LD
     obs::OP
-    function StateSpaceModel(dyn::LD, obs::OP) where {LD,OP}
-        # Check state types match
-        if eltype(dyn) != eltype(obs)[1]
-            throw(ArgumentError("State types of `dyn` and `obs` must match"))
-        end
-        return new{LD,OP}(dyn, obs)
-    end
 end
 
 """
@@ -267,7 +258,7 @@ end
     the type of the observation. This is equivalent to calling `eltype` on the observation
     process.
 """
-Base.eltype(::Type{<:StateSpaceModel{LD,OP}}) where {LD,OP} = eltype(OP)
+Base.eltype(::Type{<:StateSpaceModel{LD,OP}}) where {LD,OP} = (eltype(LD), eltype(OP))
 
 include("utils/forward_simulation.jl")
 

--- a/src/SSMProblems.jl
+++ b/src/SSMProblems.jl
@@ -53,14 +53,13 @@ function distribution(dyn::LatentDynamics, extra)
 end
 
 """
-    distribution(dyn::LatentDynamics, step::Integer, state, extra)
+    distribution(dyn::LatentDynamics, step::Integer, prev_state, extra)
 
 Return the transition distribution for the latent dynamics.
 
-The method should return the distribution of the state for the next time step given the
-current state `state` at time step `step`. The returned value should be a
-`Distributions.Distribution` object that implements sampling and log-density
-calculations. 
+The method should return the distribution of the current state (at time step `step`) given 
+the previous state `prev_state`. The returned value should be a `Distributions.Distribution`
+object that implements sampling and log-density calculations. 
 
 See also [`LatentDynamics`](@ref).
 
@@ -110,23 +109,23 @@ function simulate(dyn::LatentDynamics, extra)
 end
 
 """
-    simulate([rng::AbstractRNG], dyn::LatentDynamics, step::Integer, state, extra)
+    simulate([rng::AbstractRNG], dyn::LatentDynamics, step::Integer, prev_state, extra)
 
 Simulate a transition of the latent dynamics.
 
-The method should return a random state for the next time step given the state `state` 
-at the current time step, `step`.
+The method should return a random state for the current time step, `step`,  given the
+previous state, `prev_state`.
 
 The default behaviour is generate a random sample from distribution returned by the
 corresponding `distribution()` method.
 
 See also [`LatentDynamics`](@ref).
 """
-function simulate(rng::AbstractRNG, dyn::LatentDynamics, step::Integer, state, extra)
-    return rand(rng, distribution(dyn, step, state, extra))
+function simulate(rng::AbstractRNG, dyn::LatentDynamics, step::Integer, prev_state, extra)
+    return rand(rng, distribution(dyn, step, prev_state, extra))
 end
-function simulate(dynamics::LatentDynamics, state, step, extra)
-    return simulate(default_rng(), dynamics, state, step, extra)
+function simulate(dynamics::LatentDynamics, prev_state, step, extra)
+    return simulate(default_rng(), dynamics, prev_state, step, extra)
 end
 
 """
@@ -167,20 +166,20 @@ function logdensity(dyn::LatentDynamics, new_state, extra)
 end
 
 """
-    logdensity(dyn::LatentDynamics, step::Integer, state, new_state, extra)
+    logdensity(dyn::LatentDynamics, step::Integer, prev_state, new_state, extra)
 
 Compute the log-density of a transition of the latent dynamics.
 
-The method should return the log-density of the new state `new_state` given the current
-state `state` at time step `step`.
+The method should return the log-density of the new state `new_state` (at time step `step`)
+given the previous state `prev_state` 
 
 The default behaviour is to compute the log-density of the distribution return by the
 corresponding `distribution()` method.
 
 See also [`LatentDynamics`](@ref).
 """
-function logdensity(dyn::LatentDynamics, step::Integer, state, new_state, extra)
-    return logpdf(distribution(dyn, step, state, extra), new_state)
+function logdensity(dyn::LatentDynamics, step::Integer, prev_state, new_state, extra)
+    return logpdf(distribution(dyn, step, prev_state, extra), new_state)
 end
 
 """

--- a/src/utils/forward_simulation.jl
+++ b/src/utils/forward_simulation.jl
@@ -3,28 +3,27 @@
 import AbstractMCMC: sample
 export sample
 
-function sample(rng::AbstractRNG, model::StateSpaceModel, extras::AbstractVector)
+function sample(rng::AbstractRNG, model::StateSpaceModel, extra0, extras::AbstractVector)
     T = length(extras)
 
-    T1, T2 = eltype(model)
-    xs = Vector{T1}(undef, T)
-    ys = Vector{T2}(undef, T)
+    T_dyn, T_obs = eltype(model)
+    xs = Vector{T_dyn}(undef, T)
+    ys = Vector{T_obs}(undef, T)
 
-    x0 = simulate(rng, model.dyn)
+    x0 = simulate(rng, model.dyn, extra0)
     for t in 1:T
         xs[t] = simulate(rng, model.dyn, t, t == 1 ? x0 : xs[t - 1], extras[t])
         ys[t] = simulate(rng, model.obs, t, xs[t], extras[t])
     end
 
-    return xs, ys
+    return x0, xs, ys
 end
-function sample(model::AbstractStateSpaceModel, extras::AbstractVector)
-    return sample(default_rng(), model, extras)
+function sample(model::AbstractStateSpaceModel, extra0, extras::AbstractVector)
+    return sample(default_rng(), model, extra0, extras)
 end
 
 function sample(rng::AbstractRNG, model::AbstractStateSpaceModel, T::Integer)
-    extras = [nothing for _ in 1:T]
-    return sample(rng, model, extras)
+    return sample(rng, model, nothing, [nothing for _ in 1:T])
 end
 function sample(model::AbstractStateSpaceModel, T::Integer)
     return sample(default_rng(), model, T)

--- a/src/utils/forward_simulation.jl
+++ b/src/utils/forward_simulation.jl
@@ -6,17 +6,13 @@ export sample
 function sample(rng::AbstractRNG, model::StateSpaceModel, extras::AbstractVector)
     T = length(extras)
 
-    x0 = simulate(rng, model.dyn, extras[1])
-    y0 = simulate(rng, model.obs, 1, x0, extras[1])
+    T1, T2 = eltype(model)
+    xs = Vector{T1}(undef, T)
+    ys = Vector{T2}(undef, T)
 
-    xs = Vector{typeof(x0)}(undef, T)
-    ys = Vector{typeof(y0)}(undef, T)
-
-    xs[1] = x0
-    ys[1] = y0
-
-    for t in 2:T
-        xs[t] = simulate(rng, model.dyn, t, xs[t - 1], extras[t])
+    x0 = simulate(rng, model.dyn)
+    for t in 1:T
+        xs[t] = simulate(rng, model.dyn, t, t == 1 ? x0 : xs[t - 1], extras[t])
         ys[t] = simulate(rng, model.obs, t, xs[t], extras[t])
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,26 +8,26 @@ using Test
         μ::Float64
         σ::Float64
     end
-    SSMProblems.distribution(dyn::TestLatentDynamics) = Normal(0, 1)
+    SSMProblems.distribution(dyn::TestLatentDynamics, extra) = Normal(0, 1)
     SSMProblems.distribution(dyn::TestLatentDynamics, step::Integer, prev_state, extra) =
         Normal(prev_state + dyn.μ, dyn.σ)
 
-    struct TestObservationProcess <: ObservationProcess{Float64,Float64}
+    struct TestObservationProcess <: ObservationProcess{Float64}
         σ::Float64
     end
     SSMProblems.distribution(obs::TestObservationProcess, step::Integer, state, extra) =
         Normal(state, obs.σ)
 
     model = StateSpaceModel(TestLatentDynamics(0.1, 0.2), TestObservationProcess(0.3))
-    println(eltype(model.dyn))
 
     rng = MersenneTwister(1234)
     T = 3
+    extra0 = nothing
     extras = [nothing for _ in 1:T]
 
     # Sampling with/without rng and extras
-    @test sample(rng, model, extras) isa Tuple
+    @test sample(rng, model, extra0, extras) isa Tuple
     @test sample(rng, model, T) isa Tuple
-    @test sample(model, extras) isa Tuple
+    @test sample(model, extra0, extras) isa Tuple
     @test sample(model, T) isa Tuple
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,33 @@
+using Distributions
+using Random
+using SSMProblems
+using Test
+
+@testset "Test forward simulation" begin
+    struct TestLatentDynamics <: LatentDynamics{Float64}
+        μ::Float64
+        σ::Float64
+    end
+    SSMProblems.distribution(dyn::TestLatentDynamics) = Normal(0, 1)
+    SSMProblems.distribution(dyn::TestLatentDynamics, step::Integer, prev_state, extra) =
+        Normal(prev_state + dyn.μ, dyn.σ)
+
+    struct TestObservationProcess <: ObservationProcess{Float64,Float64}
+        σ::Float64
+    end
+    SSMProblems.distribution(obs::TestObservationProcess, step::Integer, state, extra) =
+        Normal(state, obs.σ)
+
+    model = StateSpaceModel(TestLatentDynamics(0.1, 0.2), TestObservationProcess(0.3))
+    println(eltype(model.dyn))
+
+    rng = MersenneTwister(1234)
+    T = 3
+    extras = [nothing for _ in 1:T]
+
+    # Sampling with/without rng and extras
+    @test sample(rng, model, extras) isa Tuple
+    @test sample(rng, model, T) isa Tuple
+    @test sample(model, extras) isa Tuple
+    @test sample(model, T) isa Tuple
+end


### PR DESCRIPTION
Changes:

- Modified the definitions of the interface to align the obs/dyn time steps as per #54 
- Introduced type parameters to the dyn/obs representing the state/observation types
- Used these type parameters and new alignment to refactor the forward simulation code
- Added a unit test for forward simulation

I have a fear that these new type parameters, although useful, might be a bit over-engineered and lead to sticky edge-cases. Very happy to revert those changes if others think that is best.

TODO:

- [ ] If we're happy with these type parameters, it may be worth updating the method signatures to include them, e.g. `distribution(dyn::LatentDynamics, step::Integer, prev_state, extra)` -> `distribution(dyn::LatentDynamics{T}, step::Integer, prev_state:T, extra)`. This could potentially lead to method ambiguity errors if the user misses out these types in their own definition (their dynamics will be more specific, but the documentation's state will be more specific).
- [ ] I'm currently not returning the initial state `x0` or allowing an `extra` to be passed to initialisation. This is because doing so would required `xs`/`extras` to have a zero index. This could be handled by offset arrays but that feels like a big dependency. `Kalman.jl` handles this by using a vector of pairs `t => x` but that feels clunky. I question how much the initial state/`extra` for initial are actually needed.