### PR TITLE
Add auxiliary particle filter

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 [compat]
 DataStructures = "0.18.20"
 GaussianDistributions = "0.5.2"
-SSMProblems = "0.3.0"
+SSMProblems = "0.4.0"
 StatsBase = "0.34.3"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -21,6 +21,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 [compat]
 DataStructures = "0.18.20"
 GaussianDistributions = "0.5.2"
+SSMProblems = "0.3.0"
 StatsBase = "0.34.3"
 
 [extras]

--- a/src/GeneralisedFilters.jl
+++ b/src/GeneralisedFilters.jl
@@ -73,6 +73,7 @@ function filter(
     callback=nothing,
     kwargs...,
 )
+    println("1")
     states = initialise(rng, model, alg; kwargs...)
     log_evidence = zero(eltype(model))
 
@@ -93,6 +94,7 @@ function filter(
     observations::AbstractVector;
     kwargs...,
 )
+    println("2")
     return filter(default_rng(), model, alg, observations; kwargs...)
 end
 

--- a/src/GeneralisedFilters.jl
+++ b/src/GeneralisedFilters.jl
@@ -13,6 +13,8 @@ using NNlib
 
 abstract type AbstractFilter <: AbstractSampler end
 
+abstract type AbstractParticleFilter{N} <: AbstractFilter end
+
 """
     predict([rng,] model, alg, iter, state; kwargs...)
 

--- a/src/GeneralisedFilters.jl
+++ b/src/GeneralisedFilters.jl
@@ -41,6 +41,22 @@ Perform a combined predict and update call on a single iteration of the filter.
 """
 function step end
 
+"""
+    reset_weights!(log_weights, filter)
+
+Reset container log-weights after a resampling step
+"""
+function reset_weights! end
+
+"""
+    update_weights!
+"""
+function update_weights! end
+
+function log_marginal end
+
+function update_ref! end
+
 function initialise(model, alg; kwargs...)
     return initialise(default_rng(), model, alg; kwargs...)
 end
@@ -106,6 +122,7 @@ include("models/hierarchical.jl")
 
 # Filtering/smoothing algorithms
 include("algorithms/bootstrap.jl")
+include("algorithms/apf.jl")
 include("algorithms/kalman.jl")
 include("algorithms/forward.jl")
 include("algorithms/rbpf.jl")

--- a/src/GeneralisedFilters.jl
+++ b/src/GeneralisedFilters.jl
@@ -73,7 +73,6 @@ function filter(
     callback=nothing,
     kwargs...,
 )
-    println("1")
     states = initialise(rng, model, alg; kwargs...)
     log_evidence = zero(eltype(model))
 
@@ -94,7 +93,6 @@ function filter(
     observations::AbstractVector;
     kwargs...,
 )
-    println("2")
     return filter(default_rng(), model, alg, observations; kwargs...)
 end
 

--- a/src/algorithms/apf.jl
+++ b/src/algorithms/apf.jl
@@ -50,9 +50,13 @@ function predict(
     # Compute auxilary weights
     # POC: use the simplest approximation to the predictive likelihood
     # Ideally should be something like update_weights!(filter, ...)
-    auxiliary_weights = map(
+    predicted = map(
         x -> SSMProblems.simulate(rng, model.dyn, step, x; kwargs...),
         states.filtered.particles,
+    )
+    auxiliary_weights = map(
+        x -> SSMProblems.logdensity(model.obs, step - 1, x, observation; kwargs...),
+        predicted,
     )
     state.filtered.log_weights .+= auxiliary_weights
     filter.aux = auxiliary_weights

--- a/src/algorithms/apf.jl
+++ b/src/algorithms/apf.jl
@@ -7,7 +7,7 @@ mutable struct AuxiliaryParticleFilter{RS<:AbstractConditionalResampler} <: Abst
 end
 
 function AuxiliaryParticleFilter(
-    N::Integer; threshold::Real=1.0, resampler::AbstractResampler=Systematic()
+    N::Integer; threshold::Real=0., resampler::AbstractResampler=Systematic()
 )
     conditional_resampler = ESSResampler(threshold, resampler)
     return AuxiliaryParticleFilter(N, conditional_resampler, zeros(N))

--- a/src/algorithms/apf.jl
+++ b/src/algorithms/apf.jl
@@ -1,0 +1,114 @@
+export AuxiliaryParticleFilter, APF
+
+struct AuxiliaryParticleFilter{RS<:AbstractConditionalResampler} <: AbstractFilter
+    N::Integer
+    resampler::RS
+    aux::Vector # Auxiliary weights
+end
+
+function AuxiliaryParticleFilter(
+    N::Integer, threshold::Real=1.0, resampler::AbstractResampler=Systematic()
+)
+    conditional_resampler = ESSResampler(threshold, resampler)
+    return AuxiliaryParticleFilter(N, conditional_resampler, zeros(N))
+end
+
+const APF = AuxiliaryParticleFilter
+
+function initialise(
+    rng::AbstractRNG,
+    model::StateSpaceModel{T},
+    filter::AuxiliaryParticleFilter;
+    ref_state::Union{Nothing,AbstractVector}=nothing,
+    kwargs...,
+) where {T}
+    initial_states = map(x -> SSMProblems.simulate(rng, model.dyn; kwargs...), 1:(filter.N))
+    initial_weights = fill(-log(T(filter.N)), filter.N)
+
+    return update_ref!(ParticleContainer(initial_states, initial_weights), ref_state)
+end
+
+function update_weights!(
+    rng::AbstractRNG, filter, model, step, states, observation; kwargs...
+)
+    simulation_weights = eta(rng, model, step, states, observation)
+    return states.log_weights += simulation_weights
+end
+
+function predict(
+    rng::AbstractRNG,
+    model::StateSpaceModel,
+    filter::AuxiliaryParticleFilter,
+    step::Integer,
+    states::ParticleContainer{T},
+    observation;
+    ref_state::Union{Nothing,AbstractVector{T}}=nothing,
+    kwargs...,
+) where {T}
+    # states = update_weights!(rng, filter.eta, model, step, states.filtered, observation; kwargs...)
+
+    # Compute auxilary weights
+    # POC: use the simplest approximation to the predictive likelihood
+    # Ideally should be something like update_weights!(filter, ...)
+    auxiliary_weights = map(
+        x -> SSMProblems.simulate(rng, model.dyn, step, x; kwargs...),
+        states.filtered.particles,
+    )
+    state.filtered.log_weights .+= auxiliary_weights
+    filter.aux = auxiliary_weights
+
+    states.proposed = resample(rng, filter.resampler, states.filtered, filter)
+    states.proposed.particles = map(
+        x -> SSMProblems.simulate(rng, model.dyn, step, x; kwargs...),
+        states.proposed.particles,
+    )
+
+    return update_ref!(states, ref_state, step)
+end
+
+function update(
+    model::StateSpaceModel{T},
+    filter::AuxiliaryParticleFilter,
+    step::Integer,
+    states::ParticleContainer,
+    observation;
+    kwargs...,
+) where {T}
+    @debug "step $step"
+    log_increments = map(
+        x -> SSMProblems.logdensity(model.obs, step - 1, x, observation; kwargs...),
+        collect(states.proposed.particles),
+    )
+
+    states.filtered.log_weights = states.proposed.log_weights + log_increments
+    states.filtered.particles = states.proposed.particles
+
+    return (states, logsumexp(log_increments) - log(T(filter.N)))
+end
+
+function step(
+    rng::AbstractRNG,
+    model::AbstractStateSpaceModel,
+    alg::AuxiliaryParticleFilter,
+    iter::Integer,
+    state,
+    observation;
+    kwargs...,
+)
+    proposed_state = predict(rng, model, alg, iter, state, observation; kwargs...)
+    filtered_state, ll = update(model, alg, iter, proposed_state, observation; kwargs...)
+
+    return filtered_state, ll
+end
+
+function reset_weights!(
+    state::ParticleState{T,WT}, idxs, filter::AuxiliaryParticleFilter
+) where {T,WT<:Real}
+    # From Choping: An Introduction to sequential monte carlo, section 10.3.3
+    state.log_weights = state.log_weights[idxs] - filter.aux[idxs]
+    return state
+end
+
+function logmarginal(states::ParticleContainer, ::AuxiliaryParticleFilter)
+    return logsumexp(states.filtered.log_weights) - logsumexp(states.proposed.log_weights)
+end

--- a/src/algorithms/apf.jl
+++ b/src/algorithms/apf.jl
@@ -51,12 +51,11 @@ function predict(
     # POC: use the simplest approximation to the predictive likelihood
     # Ideally should be something like update_weights!(filter, ...)
     predicted = map(
-        x -> SSMProblems.simulate(rng, model.dyn, step, x; kwargs...),
+        x -> mean(SSMProblems.distribution(model.dyn, step, x; kwargs...)),
         states.filtered.particles,
     )
     auxiliary_weights = map(
-        x -> SSMProblems.logdensity(model.obs, step - 1, x, observation; kwargs...),
-        predicted,
+        x -> SSMProblems.logdensity(model.obs, step, x, observation; kwargs...), predicted
     )
     state.filtered.log_weights .+= auxiliary_weights
     filter.aux = auxiliary_weights
@@ -80,7 +79,7 @@ function update(
 ) where {T}
     @debug "step $step"
     log_increments = map(
-        x -> SSMProblems.logdensity(model.obs, step - 1, x, observation; kwargs...),
+        x -> SSMProblems.logdensity(model.obs, step, x, observation; kwargs...),
         collect(states.proposed.particles),
     )
 

--- a/src/algorithms/bootstrap.jl
+++ b/src/algorithms/bootstrap.jl
@@ -5,6 +5,13 @@ struct BootstrapFilter{RS<:AbstractResampler} <: AbstractFilter
     resampler::RS
 end
 
+function BootstrapFilter(
+    N::Integer; threshold::Real=1.0, resampler::AbstractResampler=Systematic()
+)
+    conditional_resampler = ESSResampler(threshold, resampler)
+    return BootstrapFilter(N, conditional_resampler)
+end
+
 """Shorthand for `BootstrapFilter`"""
 const BF = BootstrapFilter
 

--- a/src/algorithms/rbpf.jl
+++ b/src/algorithms/rbpf.jl
@@ -72,7 +72,7 @@ end
 function predict(
     rng::AbstractRNG, model::HierarchicalSSM, algo::RBPF, t::Integer, states; kwargs...
 )
-    states.proposed, states.ancestors = resample(rng, algo.resampler, states.filtered)
+    states.proposed, states.ancestors = resample(rng, algo.resampler, states.filtered, algo)
 
     states.proposed.particles = map(
         x -> marginal_predict(rng, model, algo, t, x; kwargs...),

--- a/src/algorithms/rbpf.jl
+++ b/src/algorithms/rbpf.jl
@@ -108,7 +108,7 @@ function update(
 
     states.filtered.log_weights = states.proposed.log_weights + log_increments
 
-    return states, logmarginal(states)
+    return states, logmarginal(states, algo)
 end
 
 #################################

--- a/src/containers.jl
+++ b/src/containers.jl
@@ -105,9 +105,13 @@ Base.keys(state::ParticleState) = LinearIndices(state.particles)
 Base.@propagate_inbounds Base.getindex(state::ParticleState, i) = state.particles[i]
 # Base.@propagate_inbounds Base.getindex(state::ParticleState, i::Vector{Int}) = state.particles[i]
 
-function reset_weights!(state::ParticleState{T,WT}) where {T,WT<:Real}
+function reset_weights!(state::ParticleState{T,WT}, idx, ::AbstractFilter) where {T,WT<:Real}
     fill!(state.log_weights, zero(WT))
     return state.log_weights
+end
+
+function logmarginal(states::ParticleContainer, ::AbstractFilter)
+    return logsumexp(states.filtered.log_weights) - logsumexp(states.proposed.log_weights)
 end
 
 function update_ref!(

--- a/src/containers.jl
+++ b/src/containers.jl
@@ -111,7 +111,10 @@ function reset_weights!(state::ParticleState{T,WT}) where {T,WT<:Real}
 end
 
 function update_ref!(
-    pc::ParticleContainer{T}, ref_state::Union{Nothing,AbstractVector{T}}, step::Integer=0
+    pc::ParticleContainer{T},
+    ref_state::Union{Nothing,AbstractVector{T}},
+    ::AbstractFilter,
+    step::Integer=0,
 ) where {T}
     # this comes from Nicolas Chopin's package particles
     if !isnothing(ref_state)
@@ -120,10 +123,6 @@ function update_ref!(
         pc.ancestors[1] = 1
     end
     return pc
-end
-
-function logmarginal(states::ParticleContainer)
-    return logsumexp(states.filtered.log_weights) - logsumexp(states.proposed.log_weights)
 end
 
 ## SPARSE PARTICLE STORAGE #################################################################

--- a/src/containers.jl
+++ b/src/containers.jl
@@ -1,5 +1,5 @@
 using DataStructures: Stack
-using Random: rand
+import Random: rand
 
 ## GAUSSIAN STATES #########################################################################
 

--- a/src/containers.jl
+++ b/src/containers.jl
@@ -179,7 +179,7 @@ function prune!(tree::ParticleTree, offspring::Vector{Int64})
 end
 
 function insert!(
-    tree::ParticleTree{T}, states::Vector{T}, ancestors::AbstractVector{Int64}
+    tree::ParticleTree{T}, states::Vector{T}, ancestors::AbstractVector{<:Integer}
 ) where {T}
     # parents of new generation
     parents = getindex(tree.leaves, ancestors)
@@ -212,7 +212,7 @@ function expand!(tree::ParticleTree)
     return tree
 end
 
-function get_offspring(a::AbstractVector{Int64})
+function get_offspring(a::AbstractVector{<:Integer})
     offspring = zero(a)
     for i in a
         offspring[i] += 1

--- a/src/resamplers.jl
+++ b/src/resamplers.jl
@@ -8,8 +8,11 @@ export Multinomial, Systematic, Metropolis, Rejection
 abstract type AbstractResampler end
 
 function resample(
-    rng::AbstractRNG, resampler::AbstractResampler, states::ParticleState{PT,WT}, filter::U
-) where {PT,WT,U<:AbstractFilter}
+    rng::AbstractRNG,
+    resampler::AbstractResampler,
+    states::ParticleState{PT,WT},
+    filter::AbstractFilter,
+) where {PT,WT}
     weights = StatsBase.weights(states)
     idxs = sample_ancestors(rng, resampler, weights)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -122,6 +122,48 @@ end
     @test llkf ≈ llbf atol = 0.1
 end
 
+@testitem "APF filter test" begin
+    using GeneralisedFilters
+    using SSMProblems
+    using StableRNGs
+    using PDMats
+    using LinearAlgebra
+    using Random: randexp
+
+    T = Float32
+    rng = StableRNG(1234)
+    σx², σy² = randexp(rng, T, 2)
+
+    # initial state distribution
+    μ0 = zeros(T, 2)
+    Σ0 = PDMat(T[1 0; 0 1])
+
+    # state transition equation
+    A = T[1 1; 0 1]
+    b = T[0; 0]
+    Q = PDiagMat([σx²; 0])
+
+    # observation equation
+    H = T[1 0]
+    c = T[0;]
+    R = [σy²;;]
+
+    # when working with PDMats, the Kalman filter doesn't play nicely without this
+    function Base.convert(::Type{PDMat{T,MT}}, mat::MT) where {MT<:AbstractMatrix,T<:Real}
+        return PDMat(Symmetric(mat))
+    end
+
+    model = create_homogeneous_linear_gaussian_model(μ0, Σ0, A, b, Q, H, c, R)
+    _, _, data = sample(rng, model, 20)
+
+    bf = APF(2^10; threshold=0.8)
+    _, llbf = GeneralisedFilters.filter(rng, model, bf, data)
+    _, llkf = GeneralisedFilters.filter(rng, model, KF(), data)
+
+    # since this is log valued, we can up the tolerance
+    @test llkf ≈ llbf atol = 2
+end
+
 @testitem "Forward algorithm test" begin
     using GeneralisedFilters
     using Distributions

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -156,7 +156,7 @@ end
     model = create_homogeneous_linear_gaussian_model(μ0, Σ0, A, b, Q, H, c, R)
     _, _, data = sample(rng, model, 20)
 
-    bf = APF(2^10; threshold=0.8)
+    bf = APF(2^10, threshold=0.8)
     _, llbf = GeneralisedFilters.filter(rng, model, bf, data)
     _, llkf = GeneralisedFilters.filter(rng, model, KF(), data)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -109,7 +109,9 @@ end
     _, _, data = sample(rng, model, 20)
 
     bf = BF(2^12; threshold=0.8)
+    apf = APF(2^10, threshold=1.)
     bf_state, llbf = GeneralisedFilters.filter(rng, model, bf, data)
+    _, llapf= GeneralisedFilters.filter(rng, model, apf, data)
     kf_state, llkf = GeneralisedFilters.filter(rng, model, KF(), data)
 
     xs = bf_state.filtered.particles
@@ -120,48 +122,7 @@ end
 
     # since this is log valued, we can up the tolerance
     @test llkf ≈ llbf atol = 0.1
-end
-
-@testitem "APF filter test" begin
-    using GeneralisedFilters
-    using SSMProblems
-    using StableRNGs
-    using PDMats
-    using LinearAlgebra
-    using Random: randexp
-
-    T = Float32
-    rng = StableRNG(1234)
-    σx², σy² = randexp(rng, T, 2)
-
-    # initial state distribution
-    μ0 = zeros(T, 2)
-    Σ0 = PDMat(T[1 0; 0 1])
-
-    # state transition equation
-    A = T[1 1; 0 1]
-    b = T[0; 0]
-    Q = PDiagMat([σx²; 0])
-
-    # observation equation
-    H = T[1 0]
-    c = T[0;]
-    R = [σy²;;]
-
-    # when working with PDMats, the Kalman filter doesn't play nicely without this
-    function Base.convert(::Type{PDMat{T,MT}}, mat::MT) where {MT<:AbstractMatrix,T<:Real}
-        return PDMat(Symmetric(mat))
-    end
-
-    model = create_homogeneous_linear_gaussian_model(μ0, Σ0, A, b, Q, H, c, R)
-    _, _, data = sample(rng, model, 20)
-
-    bf = APF(2^10, threshold=0.8)
-    _, llbf = GeneralisedFilters.filter(rng, model, bf, data)
-    _, llkf = GeneralisedFilters.filter(rng, model, KF(), data)
-
-    # since this is log valued, we can up the tolerance
-    @test llkf ≈ llbf atol = 2
+    @test llkf ≈ llapf atol = 2
 end
 
 @testitem "Forward algorithm test" begin


### PR DESCRIPTION
Add a draft for an auxiliary particle filter. This is more of a proof of concept as we need to change the filter interface a tiny bit.
Looks like we might need to add some of these:
- `reset_weights(filter::AbstractFilter, ...)`
- `update_weights!(filter::AbstractFilter, ...)`

As well as passing the `observation` in `predict`.