### PR TITLE
Make HierarchicalSSM compatible with the BF

### DIFF
--- a/GeneralisedFilters/src/algorithms/bootstrap.jl
+++ b/GeneralisedFilters/src/algorithms/bootstrap.jl
@@ -104,3 +104,19 @@ function update(
 
     return filtered, ll_increment
 end
+
+# Application of bootstrap filter to hierarchical models
+function filter(
+    rng::AbstractRNG,
+    model::HierarchicalSSM,
+    alg::BootstrapFilter,
+    observations::AbstractVector;
+    ref_state::Union{Nothing,AbstractVector}=nothing,
+    kwargs...,
+)
+    ssm = StateSpaceModel(
+        HierarchicalDynamics(model.outer_dyn, model.inner_model.dyn),
+        HierarchicalObservations(model.inner_model.obs),
+    )
+    return filter(rng, ssm, alg, observations; ref_state=ref_state, kwargs...)
+end

--- a/GeneralisedFilters/src/models/hierarchical.jl
+++ b/GeneralisedFilters/src/models/hierarchical.jl
@@ -48,3 +48,55 @@ function AbstractMCMC.sample(
 
     return x0, z0, xs, zs, ys
 end
+
+## Methods to make HierarchicalSSM compatible with the bootstrap filter
+struct HierarchicalDynamics{T<:Real,ET,D1<:LatentDynamics{T},D2<:LatentDynamics{T}} <:
+       LatentDynamics{T,ET}
+    outer_dyn::D1
+    inner_dyn::D2
+    function HierarchicalDynamics(
+        outer_dyn::D1, inner_dyn::D2
+    ) where {D1<:LatentDynamics,D2<:LatentDynamics}
+        ET = RaoBlackwellisedParticle{eltype(outer_dyn),eltype(inner_dyn)}
+        T = SSMProblems.arithmetic_type(outer_dyn)
+        return new{T,ET,D1,D2}(outer_dyn, inner_dyn)
+    end
+end
+
+function SSMProblems.simulate(rng::AbstractRNG, dyn::HierarchicalDynamics; kwargs...)
+    outer_dyn, inner_dyn = dyn.outer_dyn, dyn.inner_dyn
+    x0 = simulate(rng, outer_dyn; kwargs...)
+    z0 = simulate(rng, inner_dyn; new_outer=x0, kwargs...)
+    return RaoBlackwellisedParticle(x0, z0)
+end
+
+function SSMProblems.simulate(
+    rng::AbstractRNG,
+    dyn::HierarchicalDynamics,
+    step::Integer,
+    prev_state::RaoBlackwellisedParticle;
+    kwargs...,
+)
+    outer_dyn, inner_dyn = dyn.outer_dyn, dyn.inner_dyn
+    x = simulate(rng, outer_dyn, step, prev_state.x; kwargs...)
+    z = simulate(
+        rng, inner_dyn, step, prev_state.z; prev_outer=prev_state.x, new_outer=x, kwargs...
+    )
+    return RaoBlackwellisedParticle(x, z)
+end
+
+struct HierarchicalObservations{T<:Real,ET,OP<:ObservationProcess{T}} <:
+       ObservationProcess{T,ET}
+    obs::OP
+    function HierarchicalObservations(obs::OP) where {OP<:ObservationProcess}
+        T = SSMProblems.arithmetic_type(obs)
+        ET = eltype(obs)
+        return new{T,ET,OP}(obs)
+    end
+end
+
+function SSMProblems.distribution(
+    obs::HierarchicalObservations, step::Integer, state::RaoBlackwellisedParticle; kwargs...
+)
+    return distribution(obs.obs, step, state.z; new_outer=state.x, kwargs...)
+end


### PR DESCRIPTION
Solves #34.

A middle-ground approach to making the HierarchicalSSM compatible with the bootstrap filter. I've add two special dynamics types and when `filter` is called with `BootstrapFilter` and `HierarchicalSSM`, the model is converted to a regular `StateSpaceModel` using these two special types.

I think a long-term ideal approach would be to introduce methods for `dynamics()` and `observations()` which construct the dynamics/observation process on the fly so that the inner functions `update`, `predict` can act on the HierarchicalSSM directly. I found this ended up being quite faffy though and require some definitions on what exactly an `AbstractStateSpaceModel` is which seems like a bit too big of a change to worry about right now (maybe later if we include mixed linear/non-linear models [1].

What do you think @charlesknipp? Fine for now?

[1] F. Lindsten, P. Bunch, S. J. Godsill and T. B. Schön, "Rao-Blackwellized particle smoothers for mixed linear/nonlinear state-space models," 2013 IEEE International Conference on Acoustics, Speech and Signal Processing, Vancouver, BC, Canada, 2013, pp. 6288-6292, doi: 10.1109/ICASSP.2013.6638875. keywords: {Trajectory;Smoothing methods;Monte Carlo methods;Approximation methods;Joints;Vectors;State-space methods;Rao-Blackwellization;particle smoothing;backward simulation;sequential Monte Carlo},
