### PR TITLE
Factor out intermediate storage

### DIFF
--- a/GeneralisedFilters/src/algorithms/kalman.jl
+++ b/GeneralisedFilters/src/algorithms/kalman.jl
@@ -239,7 +239,7 @@ struct KalmanSmoother <: AbstractSmoother end
 
 const KS = KalmanSmoother()
 
-struct StateCallback{T}
+struct StateCallback{T} <: AbstractCallback
     proposed_states::Vector{Gaussian{Vector{T},Matrix{T}}}
     filtered_states::Vector{Gaussian{Vector{T},Matrix{T}}}
 end
@@ -251,8 +251,15 @@ function StateCallback(N::Integer, T::Type)
 end
 
 function (callback::StateCallback)(
-    model::LinearGaussianStateSpaceModel, algo::KalmanFilter, states, obs; kwargs...
+    model::LinearGaussianStateSpaceModel,
+    algo::KalmanFilter,
+    iter::Integer,
+    state,
+    obs,
+    ::PostPredictCallback;
+    kwargs...,
 )
+    callback.proposed_states[iter] = deepcopy(state)
     return nothing
 end
 
@@ -260,12 +267,12 @@ function (callback::StateCallback)(
     model::LinearGaussianStateSpaceModel,
     algo::KalmanFilter,
     iter::Integer,
-    states,
-    obs;
+    state,
+    obs,
+    ::PostUpdateCallback;
     kwargs...,
 )
-    callback.proposed_states[iter] = states.proposed
-    callback.filtered_states[iter] = states.filtered
+    callback.filtered_states[iter] = deepcopy(state)
     return nothing
 end
 

--- a/GeneralisedFilters/src/callbacks.jl
+++ b/GeneralisedFilters/src/callbacks.jl
@@ -4,6 +4,42 @@ using AcceleratedKernels
 using DataStructures: Stack
 using Random: rand
 
+## ABSTRACT CALLBACK SYSTEM ################################################################
+
+abstract type AbstractCallback end
+
+abstract type CallbackTrigger end
+
+struct PostInitCallback <: CallbackTrigger end
+const PostInit = PostInitCallback()
+function (c::AbstractCallback)(model, filter, state, data, ::PostInitCallback; kwargs...)
+    return nothing
+end
+
+struct PostResampleCallback <: CallbackTrigger end
+const PostResample = PostResampleCallback()
+function (c::AbstractCallback)(
+    model, filter, step, state, data, ::PostResampleCallback; kwargs...
+)
+    return nothing
+end
+
+struct PostPredictCallback <: CallbackTrigger end
+const PostPredict = PostPredictCallback()
+function (c::AbstractCallback)(
+    model, filter, step, state, data, ::PostPredictCallback; kwargs...
+)
+    return nothing
+end
+
+struct PostUpdateCallback <: CallbackTrigger end
+const PostUpdate = PostUpdateCallback()
+function (c::AbstractCallback)(
+    model, filter, step, state, data, ::PostUpdateCallback; kwargs...
+)
+    return nothing
+end
+
 ## DENSE PARTICLE STORAGE ##################################################################
 
 struct DenseParticleContainer{T}
@@ -28,7 +64,7 @@ end
 
 A callback for dense ancestry storage, which fills a `DenseParticleContainer`.
 """
-struct DenseAncestorCallback{T}
+struct DenseAncestorCallback{T} <: AbstractCallback
     container::DenseParticleContainer{T}
 
     function DenseAncestorCallback(::Type{T}) where {T}
@@ -38,14 +74,18 @@ struct DenseAncestorCallback{T}
     end
 end
 
-function (c::DenseAncestorCallback)(model, filter, states, data; kwargs...)
-    push!(c.container.particles, deepcopy(states.filtered.particles))
+function (c::DenseAncestorCallback)(
+    model, filter, state, data, ::PostInitCallback; kwargs...
+)
+    push!(c.container.particles, deepcopy(state.particles))
     return nothing
 end
 
-function (c::DenseAncestorCallback)(model, filter, step, states, data; kwargs...)
-    push!(c.container.particles, deepcopy(states.filtered.particles))
-    push!(c.container.ancestors, deepcopy(states.ancestors))
+function (c::DenseAncestorCallback)(
+    model, filter, step, state, data, ::PostUpdateCallback; kwargs...
+)
+    push!(c.container.particles, deepcopy(state.particles))
+    push!(c.container.ancestors, deepcopy(state.ancestors))
     return nothing
 end
 
@@ -293,19 +333,22 @@ A callback for parallel sparse ancestry storage, which preallocates and returns 
 `ParallelParticleTree` object.
 """
 # TODO: this should be initialised during inference so types don't need to be predetermined
-struct ParallelAncestorCallback{T}
+struct ParallelAncestorCallback{T} <: AbstractCallback
     tree::ParallelParticleTree{T}
 end
 
-function (c::ParallelAncestorCallback)(model, filter, states, data; kwargs...)
-    # Initialisation
-    @inbounds c.tree.states[1:(filter.N)] = deepcopy(states.filtered.particles)
+function (c::ParallelAncestorCallback)(
+    model, filter, step, state, data, ::PostInitCallback; kwargs...
+)
+    @inbounds c.tree.states[1:(filter.N)] = deepcopy(state.particles)
     return nothing
 end
 
-function (c::ParallelAncestorCallback)(model, filter, step, states, data; kwargs...)
-    # TODO: this is a combined prune/insert step—split them up
-    insert!(c.tree, states.proposed.particles, states.ancestors)
+function (c::ParallelAncestorCallback)(
+    model, filter, step, state, data, ::PostUpdateCallback; kwargs...
+)
+    # insert! implicitly deepcopies
+    insert!(c.tree, state.particles, state.ancestors)
     return nothing
 end
 
@@ -317,7 +360,7 @@ end
 A callback for sparse ancestry storage, which preallocates and returns a populated 
 `ParticleTree` object.
 """
-struct AncestorCallback{T}
+struct AncestorCallback{T} <: AbstractCallback
     tree::ParticleTree{T}
 end
 
@@ -327,15 +370,16 @@ function AncestorCallback(::Type{T}, N::Integer, C::Real=1.0) where {T}
     return new{T}(ParticleTree(nodes, M))
 end
 
-function (c::AncestorCallback)(model, filter, intermediate, data; kwargs...)
-    # Initialisation
-    @inbounds c.tree.states[1:(filter.N)] = deepcopy(intermediate.filtered.particles)
+function (c::AncestorCallback)(model, filter, state, data, ::PostInitCallback; kwargs...)
+    @inbounds c.tree.states[1:(filter.N)] = deepcopy(state.particles)
     return nothing
 end
 
-function (c::AncestorCallback)(model, filter, step, intermediate, data; kwargs...)
-    prune!(c.tree, get_offspring(intermediate.ancestors))
-    insert!(c.tree, intermediate.proposed.particles, intermediate.ancestors)
+function (c::AncestorCallback)(
+    model, filter, step, state, data, ::PostPredictCallback; kwargs...
+)
+    prune!(c.tree, get_offspring(state.ancestors))
+    insert!(c.tree, state.particles, state.ancestors)
     return nothing
 end
 
@@ -345,7 +389,7 @@ end
 A callback which follows the resampling indices over the filtering algorithm. This is more
 of a debug tool and visualizer for various resapmling algorithms.
 """
-struct ResamplerCallback
+struct ResamplerCallback <: AbstractCallback
     tree::ParticleTree
 
     function ResamplerCallback(N::Integer, C::Real=1.0)
@@ -355,10 +399,12 @@ struct ResamplerCallback
     end
 end
 
-function (c::ResamplerCallback)(model, filter, step, states, data; kwargs...)
+function (c::ResamplerCallback)(
+    model, filter, step, state, data, ::PostResampleCallback; kwargs...
+)
     if step != 1
-        prune!(c.tree, get_offspring(states.ancestors))
-        insert!(c.tree, collect(1:(filter.N)), states.ancestors)
+        prune!(c.tree, get_offspring(state.ancestors))
+        insert!(c.tree, collect(1:(filter.N)), state.ancestors)
     end
     return nothing
 end

--- a/GeneralisedFilters/src/containers.jl
+++ b/GeneralisedFilters/src/containers.jl
@@ -1,18 +1,5 @@
 """Containers used for storing representations of the filtering distribution."""
 
-## INTERMEDIATES ###########################################################################
-
-mutable struct ParticleIntermediate{DT,AT}
-    proposed::DT
-    filtered::DT
-    ancestors::AT
-end
-
-mutable struct Intermediate{DT}
-    proposed::DT
-    filtered::DT
-end
-
 ## PARTICLES ###############################################################################
 
 """
@@ -23,7 +10,12 @@ object, with the states (or particles) distributed accoring to their log-weights
 """
 mutable struct ParticleDistribution{PT,WT<:Real}
     particles::Vector{PT}
+    ancestors::Vector{Int}
     log_weights::Vector{WT}
+end
+function ParticleDistribution(particles::Vector{PT}, log_weights::Vector{WT}) where {PT,WT}
+    N = length(particles)
+    return ParticleDistribution(particles, Vector{Int}(1:N), log_weights)
 end
 
 StatsBase.weights(state::ParticleDistribution) = softmax(state.log_weights)
@@ -76,7 +68,14 @@ mutable struct RaoBlackwellisedParticleDistribution{
     T,M<:CUDA.AbstractMemory,PT<:BatchRaoBlackwellisedParticles
 }
     particles::PT
-    log_weights::CuArray{T,1,M}
+    ancestors::CuVector{Int,M}
+    log_weights::CuVector{T,M}
+end
+function RaoBlackwellisedParticleDistribution(
+    particles::PT, log_weights::CuVector{T,M}
+) where {T,M,PT}
+    N = length(particles)
+    return RaoBlackwellisedParticleDistribution(particles, CuVector{Int}(1:N), log_weights)
 end
 
 function StatsBase.weights(state::RaoBlackwellisedParticleDistribution)


### PR DESCRIPTION
This PR completely removes intermediate storage (solving #37) and makes changes to the callback system to be compatible with this change. The main points are:

- The ancestors are now stored in the particle distribution. This doesn't change functionality at all as far as I can tell.
- The callbacks are now parameterised by a subtype of `CallbackTrigger` e.g. `PostPredictCallback`. These can be added by the user if they have a special time they want to callback. It's a bit of a pain that these need default implementations that do nothing—this is also quite annoying in that it fails silently if you get the type signature wrong in your callback definition as it just runs the default that does nothing. There's probably a cleaner way to do this but I think this is fine for this PR
- This change means we can get rid of all deep copies in the filtering code (🎉🥳) and let's us do some nice in-place operations making the predict/update cleaner. This does mean that all callbacks need to deepcopy now but they should have been doing that already. Solves #27.

The only issue this introduces is that it makes the guided filter a bit harder to implement since the old log weights are "forgotten" by the time we get to the `update` step. There are definitely a few options of how to handle this so not too worried for now—just a case of finding the most elegant.

Let me know if @charlesknipp @FredericWantiez have any thoughts otherwise I will merge soonish so you guys can build on this modified interface.