### PR TITLE
Unified interface for batched filters

### DIFF
--- a/GeneralisedFilters/src/GeneralisedFilters.jl
+++ b/GeneralisedFilters/src/GeneralisedFilters.jl
@@ -17,6 +17,9 @@ include("callbacks.jl")
 include("containers.jl")
 include("resamplers.jl")
 
+# Batching utilities
+include("batching/batched_CUDA.jl")
+
 ## FILTERING BASE ##########################################################################
 
 abstract type AbstractFilter <: AbstractSampler end

--- a/GeneralisedFilters/src/GeneralisedFilters.jl
+++ b/GeneralisedFilters/src/GeneralisedFilters.jl
@@ -18,7 +18,9 @@ include("containers.jl")
 include("resamplers.jl")
 
 # Batching utilities
+include("batching/batching.jl")
 include("batching/batched_CUDA.jl")
+include("batching/batched_SA.jl")
 
 ## FILTERING BASE ##########################################################################
 

--- a/GeneralisedFilters/src/batching/batched_CUDA.jl
+++ b/GeneralisedFilters/src/batching/batched_CUDA.jl
@@ -1,0 +1,181 @@
+import Base: *, +, -, transpose, getindex
+import LinearAlgebra: Transpose, cholesky, \, I, UniformScaling
+
+export BatchedCuVector, BatchedCuMatrix, BatchedCuCholesky
+
+###########################
+#### VECTOR OPERATIONS ####
+###########################
+
+struct BatchedCuVector{T}
+    data::CuArray{T,2,CUDA.DeviceMemory}
+    ptrs::CuVector{CuPtr{T},CUDA.DeviceMemory}
+end
+function BatchedCuVector(data::CuArray{T,2}) where {T}
+    ptrs = CUDA.CUBLAS.unsafe_strided_batch(data)
+    return BatchedCuVector{T}(data, ptrs)
+end
+Base.eltype(::BatchedCuVector{T}) where {T} = T
+
+function +(x::BatchedCuVector{T}, y::BatchedCuVector{T}) where {T}
+    z_data = x.data .+ y.data
+    return BatchedCuVector(z_data)
+end
+
+function -(x::BatchedCuVector{T}, y::BatchedCuVector{T}) where {T}
+    z_data = x.data .- y.data
+    return BatchedCuVector(z_data)
+end
+
+###########################
+#### MATRIX OPERATIONS ####
+###########################
+
+struct BatchedCuMatrix{T}
+    data::CuArray{T,3,CUDA.DeviceMemory}
+    ptrs::CuVector{CuPtr{T},CUDA.DeviceMemory}
+end
+function BatchedCuMatrix(data::CuArray{T,3}) where {T}
+    ptrs = CUDA.CUBLAS.unsafe_strided_batch(data)
+    return BatchedCuMatrix{T}(data, ptrs)
+end
+Base.eltype(::BatchedCuMatrix{T}) where {T} = T
+
+transpose(A::BatchedCuMatrix{T}) where {T} = Transpose{T,BatchedCuMatrix{T}}(A)
+
+function *(A::BatchedCuMatrix{T}, B::BatchedCuMatrix{T}) where {T}
+    C_data = CUDA.CUBLAS.gemm_strided_batched('N', 'N', A.data, B.data)
+    return BatchedCuMatrix(C_data)
+end
+function *(A::Transpose{T,BatchedCuMatrix{T}}, B::BatchedCuMatrix{T}) where {T}
+    C_data = CUDA.CUBLAS.gemm_strided_batched('T', 'N', A.parent.data, B.data)
+    return BatchedCuMatrix(C_data)
+end
+function *(A::BatchedCuMatrix{T}, B::Transpose{T,BatchedCuMatrix{T}}) where {T}
+    C_data = CUDA.CUBLAS.gemm_strided_batched('N', 'T', A.data, B.parent.data)
+    return BatchedCuMatrix(C_data)
+end
+function *(A::Transpose{T,BatchedCuMatrix{T}}, B::Transpose{T,BatchedCuMatrix{T}}) where {T}
+    C_data = CUDA.CUBLAS.gemm_strided_batched('T', 'T', A.parent.data, B.parent.data)
+    return BatchedCuMatrix(C_data)
+end
+
+function +(A::BatchedCuMatrix{T}, B::BatchedCuMatrix{T}) where {T}
+    C_data = A.data .+ B.data
+    return BatchedCuMatrix(C_data)
+end
+
+function -(A::BatchedCuMatrix{T}, B::BatchedCuMatrix{T}) where {T}
+    C_data = A.data .- B.data
+    return BatchedCuMatrix(C_data)
+end
+
+function +(A::BatchedCuMatrix{T}, J::UniformScaling{<:Union{T,Bool}}) where {T}
+    m, n = size(A.data, 1), size(A.data, 2)
+    m == n || throw(DimensionMismatch("Matrix must be square for UniformScaling addition"))
+    B_data = copy(A.data)
+    for i in 1:m
+        B_data[i, i, :] .+= J.λ
+    end
+    return BatchedCuMatrix(B_data)
+end
+
+##################################
+#### MATRIX-VECTOR OPERATIONS ####
+##################################
+
+function *(A::BatchedCuMatrix{T}, x::BatchedCuVector{T}) where {T}
+    y_data = CuArray{T}(undef, size(A.data, 1), size(x.data, 2))
+    CUDA.CUBLAS.gemv_strided_batched('N', T(1.0), A.data, x.data, T(0.0), y_data)
+    return BatchedCuVector(y_data)
+end
+function *(A::Transpose{T,BatchedCuMatrix{T}}, x::BatchedCuVector{T}) where {T}
+    y_data = CuArray{T}(undef, size(A.data, 2), size(x.data, 2))
+    CUDA.CUBLAS.gemv_strided_batched('T', T(1.0), A.data, x.data, T(0.0), y_data)
+    return BatchedCuVector(y_data)
+end
+
+function getindex(A::BatchedCuMatrix{T}, i::Int, ::Colon) where {T}
+    row_data = A.data[i, :, :]
+    return BatchedCuVector(row_data)
+end
+function getindex(A::BatchedCuMatrix{T}, ::Colon, j::Int) where {T}
+    col_data = A.data[:, j, :]
+    return BatchedCuVector(col_data)
+end
+
+#########################
+#### POTR OPERATIONS ####
+#########################
+
+struct BatchedCuCholesky{T}
+    data::CuArray{T,3,CUDA.DeviceMemory}
+    ptrs::CuVector{CuPtr{T},CUDA.DeviceMemory}
+end
+function BatchedCuCholesky(data::CuArray{T,3}) where {T}
+    ptrs = CUDA.CUBLAS.unsafe_strided_batch(data)
+    return BatchedCuCholesky{T}(data, ptrs)
+end
+Base.eltype(::BatchedCuCholesky{T}) where {T} = T
+
+for (fname, elty) in (
+    (:cusolverDnSpotrfBatched, :Float32),
+    (:cusolverDnDpotrfBatched, :Float64),
+    (:cusolverDnCpotrfBatched, :ComplexF32),
+    (:cusolverDnZpotrfBatched, :ComplexF64),
+)
+    @eval begin
+        function cholesky(A::BatchedCuMatrix{$elty})
+            # HACK: assuming A is positive definite
+            m, n, b = size(A.data)
+            m == n ||
+                throw(DimensionMismatch("Matrix must be square for Cholesky decomposition"))
+
+            L_data = copy(A.data)
+            L = BatchedCuCholesky(L_data)
+
+            dh = CUDA.CUSOLVER.dense_handle()
+            info = CuVector{Int}(undef, b)
+            CUDA.CUSOLVER.$fname(dh, 'L', m, L.ptrs, m, info, b)
+
+            return L
+        end
+    end
+end
+
+# TODO: CUSOLVER does not support matrix RHS for potrs; replace with MAGMA
+for (fname, elty) in (
+    (:cusolverDnSpotrsBatched, :Float32),
+    (:cusolverDnDpotrsBatched, :Float64),
+    (:cusolverDnCpotrsBatched, :ComplexF32),
+    (:cusolverDnZpotrsBatched, :ComplexF64),
+)
+    @eval begin
+        function \(L::BatchedCuCholesky{$elty}, A::BatchedCuMatrix{$elty})
+            m, n, b, = size(A.data)
+            # CUSOLVER does not support matrix RHS for potrs so solve each column separately
+            bs_data = Vector{CuMatrix{$elty}}(undef, n)
+            for i in 1:n
+                bs_data[i] = A.data[:, i, :]
+                b_ptr = CUDA.CUBLAS.unsafe_strided_batch(bs_data[i])
+
+                dh = CUDA.CUSOLVER.dense_handle()
+                info = CuVector{Int}(undef, b)
+                CUDA.CUSOLVER.$fname(dh, 'L', m, 1, L.ptrs, m, b_ptr, m, info, b)
+            end
+
+            B_data = stack(bs_data; dims=2)
+            return BatchedCuMatrix(B_data)
+        end
+    end
+end
+
+##########################
+#### MIXED OPERATIONS ####
+##########################
+
+function -(x::CuVector{T}, y::BatchedCuVector{T}) where {T}
+    z_data = x .- y.data
+    return BatchedCuVector(z_data)
+end
+

--- a/GeneralisedFilters/src/batching/batched_CUDA.jl
+++ b/GeneralisedFilters/src/batching/batched_CUDA.jl
@@ -19,6 +19,7 @@ function BatchedCuVector(data::CuArray{T,2}) where {T}
 end
 Base.eltype(::BatchedCuVector{T}) where {T} = T
 Base.length(x::BatchedCuVector) = size(x.data, 2)
+Base.getindex(x::BatchedCuVector, idxs) = BatchedCuVector(x.data[:, idxs])
 
 function +(x::BatchedCuVector{T}, y::BatchedCuVector{T}) where {T}
     z_data = x.data .+ y.data
@@ -52,6 +53,7 @@ function BatchedCuMatrix(data::CuArray{T,3}) where {T}
 end
 Base.eltype(::BatchedCuMatrix{T}) where {T} = T
 Base.length(A::BatchedCuMatrix) = size(A.data, 3)
+Base.getindex(A::BatchedCuMatrix, idxs) = BatchedCuMatrix(A.data[:, :, idxs])
 
 transpose(A::BatchedCuMatrix{T}) where {T} = Transpose{T,BatchedCuMatrix{T}}(A)
 
@@ -143,6 +145,7 @@ function BatchedCuCholesky(data::CuArray{T,3}) where {T}
 end
 Base.eltype(::BatchedCuCholesky{T}) where {T} = T
 Base.length(P::BatchedCuCholesky) = size(P.data, 3)
+Base.getindex(P::BatchedCuCholesky, idxs) = BatchedCuCholesky(P.data[:, :, idxs])
 
 for (fname, elty) in (
     (:cusolverDnSpotrfBatched, :Float32),

--- a/GeneralisedFilters/src/batching/batched_SA.jl
+++ b/GeneralisedFilters/src/batching/batched_SA.jl
@@ -1,0 +1,8 @@
+import StaticArrays: SVector, SMatrix
+
+struct BatchedSAVector{T} <: BatchedVector{T}
+    data::Array{T,2}
+end
+Base.eltype(::BatchedSAVector{T}) where {T} = T
+
+

--- a/GeneralisedFilters/src/batching/batching.jl
+++ b/GeneralisedFilters/src/batching/batching.jl
@@ -1,0 +1,2 @@
+abstract type BatchedVector{T} end
+abstract type BatchedMatrix{T} end

--- a/GeneralisedFilters/src/containers.jl
+++ b/GeneralisedFilters/src/containers.jl
@@ -8,12 +8,12 @@
 A container for particle filters which composes the weighted sample into a distibution-like
 object, with the states (or particles) distributed accoring to their log-weights.
 """
-mutable struct ParticleDistribution{PT,WT<:Real}
-    particles::Vector{PT}
+mutable struct ParticleDistribution{PT,WT}
+    particles::PT
     ancestors::Vector{Int}
-    log_weights::Vector{WT}
+    log_weights::WT
 end
-function ParticleDistribution(particles::Vector{PT}, log_weights::Vector{WT}) where {PT,WT}
+function ParticleDistribution(particles, log_weights)
     N = length(particles)
     return ParticleDistribution(particles, Vector{Int}(1:N), log_weights)
 end

--- a/GeneralisedFilters/src/containers.jl
+++ b/GeneralisedFilters/src/containers.jl
@@ -8,14 +8,19 @@
 A container for particle filters which composes the weighted sample into a distibution-like
 object, with the states (or particles) distributed accoring to their log-weights.
 """
-mutable struct ParticleDistribution{PT,WT}
+mutable struct ParticleDistribution{PT,AT,WT}
     particles::PT
-    ancestors::Vector{Int}
+    ancestors::AT
     log_weights::WT
 end
-function ParticleDistribution(particles, log_weights)
+# TODO: these helpers might be more confusing than they're worth — and don't cover all cases
+function ParticleDistribution(particles, log_weights::Vector)
     N = length(particles)
     return ParticleDistribution(particles, Vector{Int}(1:N), log_weights)
+end
+function ParticleDistribution(particles, log_weights::CuVector)
+    N = length(particles)
+    return ParticleDistribution(particles, CuVector{Int}(1:N), log_weights)
 end
 
 StatsBase.weights(state::ParticleDistribution) = softmax(state.log_weights)

--- a/GeneralisedFilters/src/models/linear_gaussian.jl
+++ b/GeneralisedFilters/src/models/linear_gaussian.jl
@@ -52,23 +52,24 @@ end
 #### DISTRIBUTIONS ####
 #######################
 
+# We choose Gaussian over MvNormal since it allows for batched types
 function SSMProblems.distribution(dyn::LinearGaussianLatentDynamics; kwargs...)
     μ0, Σ0 = calc_initial(dyn; kwargs...)
-    return MvNormal(μ0, Σ0)
+    return Gaussian(μ0, Σ0)
 end
 
 function SSMProblems.distribution(
-    dyn::LinearGaussianLatentDynamics, step::Integer, state::AbstractVector; kwargs...
+    dyn::LinearGaussianLatentDynamics, step::Integer, state; kwargs...
 )
     A, b, Q = calc_params(dyn, step; kwargs...)
-    return MvNormal(A * state + b, Q)
+    return Gaussian(A * state + b, Q)
 end
 
 function SSMProblems.distribution(
-    obs::LinearGaussianObservationProcess, step::Integer, state::AbstractVector; kwargs...
+    obs::LinearGaussianObservationProcess, step::Integer, state; kwargs...
 )
     H, c, R = calc_params(obs, step; kwargs...)
-    return MvNormal(H * state + c, R)
+    return Gaussian(H * state + c, R)
 end
 
 ###########################################

--- a/GeneralisedFilters/src/models/linear_gaussian.jl
+++ b/GeneralisedFilters/src/models/linear_gaussian.jl
@@ -76,12 +76,17 @@ end
 ###########################################
 
 struct HomogeneousLinearGaussianLatentDynamics{
-    T<:Real,ΣT<:AbstractMatrix{T},AT<:AbstractMatrix{T},QT<:AbstractMatrix{T}
+    T<:Real,
+    μT<:Union{AbstractVector{T},BatchedVector{T}},
+    ΣT<:Union{AbstractMatrix{T},BatchedMatrix{T}},
+    AT<:Union{AbstractMatrix{T},BatchedMatrix{T}},
+    bT<:Union{AbstractVector{T},BatchedVector{T}},
+    QT<:Union{AbstractMatrix{T},BatchedMatrix{T}},
 } <: LinearGaussianLatentDynamics{T}
-    μ0::Vector{T}
+    μ0::μT
     Σ0::ΣT
     A::AT
-    b::Vector{T}
+    b::bT
     Q::QT
 end
 calc_μ0(dyn::HomogeneousLinearGaussianLatentDynamics; kwargs...) = dyn.μ0
@@ -91,10 +96,13 @@ calc_b(dyn::HomogeneousLinearGaussianLatentDynamics, ::Integer; kwargs...) = dyn
 calc_Q(dyn::HomogeneousLinearGaussianLatentDynamics, ::Integer; kwargs...) = dyn.Q
 
 struct HomogeneousLinearGaussianObservationProcess{
-    T<:Real,HT<:AbstractMatrix{T},RT<:AbstractMatrix{T}
+    T<:Real,
+    HT<:Union{AbstractMatrix{T},BatchedMatrix{T}},
+    cT<:Union{AbstractVector{T},BatchedVector{T}},
+    RT<:Union{AbstractMatrix{T},BatchedMatrix{T}},
 } <: LinearGaussianObservationProcess{T}
     H::HT
-    c::Vector{T}
+    c::cT
     R::RT
 end
 calc_H(obs::HomogeneousLinearGaussianObservationProcess, ::Integer; kwargs...) = obs.H

--- a/GeneralisedFilters/src/resamplers.jl
+++ b/GeneralisedFilters/src/resamplers.jl
@@ -23,7 +23,7 @@ function resample(
 end
 
 function construct_new_state(states::ParticleDistribution{PT,WT}, idxs) where {PT,WT}
-    return ParticleDistribution(states.particles[idxs], idxs, zeros(WT, length(states)))
+    return ParticleDistribution(states.particles[idxs], idxs, zero(states.log_weights))
 end
 
 function construct_new_state(

--- a/GeneralisedFilters/test/runtests.jl
+++ b/GeneralisedFilters/test/runtests.jl
@@ -108,7 +108,6 @@ end
     using LogExpFunctions: softmax
     using CUDA
     using LinearAlgebra
-    using GeneralisedFilters
 
     rng = StableRNG(1234)
     model = GeneralisedFilters.GFTest.create_linear_gaussian_model(rng, 1, 1)
@@ -128,8 +127,7 @@ end
         ),
     )
 
-    # HACK: disabling resampling for now
-    bf = BF(2^12; threshold=0.0)
+    bf = BF(2^12; threshold=1.0)
     # HACK: run BF manually until initialisation interface is finalised
     # Initialisation
     Z = BatchedCuVector(CUDA.randn(Float32, 1, bf.N))


### PR DESCRIPTION
This PR aims to solve #47 by handling batched filtering through dispatch rather than defining replacement algorithms.

The core idea of the PR is already there and demonstrated in the `batch_kalman_test.jl` file. Note that `BatchKalmanFilter` is now gone, which is great for reducing code duplication!

Instead, the batched behaviour is taken care of through special batch types that use dispatch to create wrappers around CuBLAS, CuSolver functions. These types and wrappers are included in this package now for ease, but the goal is to separate these out into their own package in the near future, since they have far wider use cases.

I still have a few more things to do:

- [x] Update resampling to followed batched interface
- [ ] Integrate these changes with the RBPF
- [ ] Remove legacy batching code
- [ ] Create a CPU batched type using static arrays
- [ ] Create a MAGMA wrapper and use LocalPreferences to determine which backend to use
- [ ] Bring in my fused CUDA kernels (again using LocalPreferences to enable)

I would like to stress that this PR is only implementing the bare basics of this interface. I.e. it is not necessarily meant to be fast, clean, or feature-complete, but rather just define the interface. These changes are not really the responsibility of GeneralisedFilters, but rather the batching interface.

The main improvements to be made (in a future PR) are:

- Tighten up the transposition/factorization/adjoint interface, basing the approach on how `LinearAlgebra` handles these (the current approach is fairly hacked together based around our current needs—notably, I haven't defined `Adjoint`, just `Transpose` and so the KF had to be changed to use `transpose` for now.
- Automatically generate methods for mixed batched + singular operations (currently just manually added the ones we use)
- Maybe make the pointer creation lazy — these aren't needed for "strided" kernels
- Error checking (e.g. dims, batch count) is currently handled by the low-level CUDA functions, which aren't always the clearest.

Finally, I initially planned to have `BatchedCuMatrix` be a subtype of `AbstractMatrix` since that's kind of how it behaves. I think this might not be possible however as `AbstractMatrix` defines specific behaviour for how matrices get displayed in the REPL and I doubt our batched matrices can conform to this interface (which leads to errors when printed). For now, I'm using `Union{AbstractMatrix, BatchedMatrix}` is type signatures.

Thoughts and feedback would be greatly appreciated.