### PR TITLE
Implementation of Rao-Blackwellised Ancestor Sampling

### DIFF
--- a/GeneralisedFilters/src/GeneralisedFilters.jl
+++ b/GeneralisedFilters/src/GeneralisedFilters.jl
@@ -22,7 +22,7 @@ include("resamplers.jl")
 ## FILTERING BASE ##########################################################################
 
 abstract type AbstractFilter <: AbstractSampler end
-abstract type AbstractBackwardFilter <: AbstractSampler end
+abstract type AbstractBackwardPredictor <: AbstractSampler end
 
 """
     initialise([rng,] model, algo; kwargs...)

--- a/GeneralisedFilters/src/GeneralisedFilters.jl
+++ b/GeneralisedFilters/src/GeneralisedFilters.jl
@@ -57,7 +57,7 @@ function initialise(model, algo; kwargs...)
 end
 
 function predict(model, algo, step, filtered, observation; kwargs...)
-    return predict(default_rng(), model, algo, step, filtered; kwargs...)
+    return predict(default_rng(), model, algo, step, filtered, observation; kwargs...)
 end
 
 function filter(
@@ -146,6 +146,8 @@ include("algorithms/particles.jl")
 include("algorithms/kalman.jl")
 include("algorithms/forward.jl")
 include("algorithms/rbpf.jl")
+
+include("ancestor_sampling.jl")
 
 # Unit-testing helper module
 include("GFTest/GFTest.jl")

--- a/GeneralisedFilters/src/GeneralisedFilters.jl
+++ b/GeneralisedFilters/src/GeneralisedFilters.jl
@@ -12,6 +12,8 @@ using StatsBase
 using CUDA
 using NNlib
 
+export initialise, predict, update
+
 # Filtering utilities
 include("callbacks.jl")
 include("containers.jl")
@@ -20,6 +22,7 @@ include("resamplers.jl")
 ## FILTERING BASE ##########################################################################
 
 abstract type AbstractFilter <: AbstractSampler end
+abstract type AbstractBackwardFilter <: AbstractSampler end
 
 """
     initialise([rng,] model, algo; kwargs...)

--- a/GeneralisedFilters/src/ancestor_sampling.jl
+++ b/GeneralisedFilters/src/ancestor_sampling.jl
@@ -1,0 +1,54 @@
+import LinearAlgebra: I, cholesky, logdet
+
+export ancestor_weight
+
+function ancestor_weight(
+    dyn::LatentDynamics, ::AbstractFilter, iter::Integer, state, ref_state; kwargs...
+)
+    return SSMProblems.logdensity(dyn, iter, state, ref_state; kwargs...)
+end
+
+function ancestor_weight(
+    dyn::HierarchicalDynamics,
+    algo::RBPF,
+    iter::Integer,
+    state::RBState,
+    ref_state::RBState{<:Any,<:InformationDistribution};
+    kwargs...,
+)
+    trans_weight = ancestor_weight(
+        dyn.outer_dyn, algo.pf, iter, state.x, ref_state.x; kwargs...
+    )
+    filt_dist = state.z
+    # A representation of the predictive likelihood p(y_{t+1:T} | z_{t+1}) conditioned on
+    # the reference trajectory
+    back_info = ref_state.z
+
+    # Predict filtering distribution using reference state
+    # TODO: this is wasteful if prediction doesn't depend on the new outer state
+    pred_dist = predict(
+        default_rng(),
+        dyn.inner_dyn,
+        algo.af,
+        iter,
+        filt_dist,
+        nothing;
+        prev_outer=state.x,
+        new_outer=ref_state.x,
+        kwargs...,
+    )
+
+    # Apply two filter formula to get p(y_{t+1:T} | y_{1:t}, x_{1:t})
+    # Or is it p(y_{t+1:T} | y_{1:t}, x_{1:T})?
+    μ, Σ = mean_cov(pred_dist)
+    λ, Ω = natural_params(back_info)
+    Γ = cholesky(Σ).L
+
+    # Apply two-filter smoother style formula
+    # TODO: Clean this up with Mahalanobis distance helper
+    Λ = Γ' * Ω * Γ + I
+    M = Γ' * (λ - Ω * μ)
+    ζ = μ' * Ω * μ - 2 * λ' * μ - M' * inv(Λ) * M
+
+    return trans_weight + -0.5 * (logdet(Λ) + ζ)
+end

--- a/GeneralisedFilters/src/containers.jl
+++ b/GeneralisedFilters/src/containers.jl
@@ -82,3 +82,26 @@ end
 function mean_cov(state::GaussianDistribution)
     return state.μ, state.Σ
 end
+
+struct InformationDistribution{λT,ΩT}
+    λ::λT
+    Ω::ΩT
+end
+
+function natural_params(state::InformationDistribution)
+    return state.λ, state.Ω
+end
+
+# Conversions — explicit since these may fail if the covariance/precision is not invertible
+function GaussianDistribution(state::InformationDistribution)
+    λ, Ω = natural_params(state)
+    Σ = inv(Ω)
+    μ = Σ * λ
+    return GaussianDistribution(μ, Σ)
+end
+function InformationDistribution(state::GaussianDistribution)
+    μ, Σ = mean_cov(state)
+    Ω = inv(Σ)
+    λ = Ω * μ
+    return InformationDistribution(λ, Ω)
+end

--- a/GeneralisedFilters/test/runtests.jl
+++ b/GeneralisedFilters/test/runtests.jl
@@ -64,7 +64,7 @@ end
         _, _, ys = sample(rng, model, T)
 
         # Perform backward information filtering
-        BIF = BackwardInformationFilter()
+        BIF = BackwardInformationPredictor()
         predictive_likelihood = backward_initialise(rng, model.obs, BIF, T, ys[T])
         predictive_likelihood = backward_predict(
             rng, model.dyn, BIF, T - 1, predictive_likelihood
@@ -732,21 +732,25 @@ end
         ref_traj = getproperty.(ref_traj, :x)
 
         pred_lik = backward_initialise(
-            rng, hier_model.inner_model.obs, BackwardInformationFilter(), K, ys[K]
+            rng, hier_model.inner_model.obs, BackwardInformationPredictor(), K, ys[K]
         )
         predictive_likelihoods[K] = deepcopy(pred_lik)
         for t in (K - 1):-1:1
             pred_lik = backward_predict(
                 rng,
                 hier_model.inner_model.dyn,
-                BackwardInformationFilter(),
+                BackwardInformationPredictor(),
                 t,
                 pred_lik;
                 prev_outer=ref_traj[t],
                 next_outer=ref_traj[t + 1],
             )
             pred_lik = backward_update(
-                hier_model.inner_model.obs, BackwardInformationFilter(), t, pred_lik, ys[t]
+                hier_model.inner_model.obs,
+                BackwardInformationPredictor(),
+                t,
+                pred_lik,
+                ys[t],
             )
             predictive_likelihoods[t] = deepcopy(pred_lik)
         end

--- a/GeneralisedFilters/test/runtests.jl
+++ b/GeneralisedFilters/test/runtests.jl
@@ -505,7 +505,7 @@ end
     K = 10
     t_smooth = 2
     T = Float64
-    N_particles = 10
+    N_particles = 10  # Use small particle number so impact of ref state is significant
     N_burnin = 1000
     N_sample = 100000
 
@@ -566,9 +566,9 @@ end
     K = 5
     t_smooth = 2
     T = Float64
-    N_particles = 100
-    N_burnin = 200
-    N_sample = 2000
+    N_particles = 10  # Use small particle number so impact of ref state is significant
+    N_burnin = 1000
+    N_sample = 10000
 
     rng = StableRNG(SEED)
     full_model, hier_model = GeneralisedFilters.GFTest.create_dummy_linear_gaussian_model(
@@ -600,6 +600,156 @@ end
         end
         # Reference trajectory should only be nonlinear state for RBPF
         ref_traj = getproperty.(ref_traj, :x)
+    end
+
+    # Extract inner and outer trajectories
+    x_trajectories = getproperty.(getindex.(trajectory_samples, t_smooth), :x)
+
+    # Manually perform smoothing until we have a cleaner interface
+    A = hier_model.inner_model.dyn.A
+    b = hier_model.inner_model.dyn.b
+    C = hier_model.inner_model.dyn.C
+    Q = hier_model.inner_model.dyn.Q
+    z_smoothed_means = Vector{T}(undef, N_sample)
+    for i in 1:N_sample
+        μ = trajectory_samples[i][K].z.μ
+        Σ = trajectory_samples[i][K].z.Σ
+
+        for t in (K - 1):-1:t_smooth
+            μ_filt = trajectory_samples[i][t].z.μ
+            Σ_filt = trajectory_samples[i][t].z.Σ
+            μ_pred = A * μ_filt + b + C * trajectory_samples[i][t].x
+            Σ_pred = A * Σ_filt * A' + Q
+
+            G = Σ_filt * A' * inv(Σ_pred)
+            μ = μ_filt .+ G * (μ .- μ_pred)
+            Σ = Σ_filt .+ G * (Σ .- Σ_pred) * G'
+        end
+
+        z_smoothed_means[i] = only(μ)
+    end
+
+    # Compare to ground truth
+    @test state.μ[1] ≈ only(mean(x_trajectories)) rtol = 1e-2
+    @test state.μ[2] ≈ mean(z_smoothed_means) rtol = 1e-3
+end
+
+@testitem "RBCSMC-AS test" begin
+    using GeneralisedFilters
+    using StableRNGs
+    using PDMats
+    using LinearAlgebra
+    using Random: randexp
+    using StatsBase: sample, weights
+    using StaticArrays
+    using Statistics
+    using LogExpFunctions
+
+    import SSMProblems: prior, dyn, obs
+    import GeneralisedFilters: resampler, resample, move, RBState, InformationDistribution
+
+    using OffsetArrays
+
+    SEED = 1234
+    D_outer = 1
+    D_inner = 1
+    D_obs = 1
+    K = 5
+    t_smooth = 2
+    T = Float64
+    N_particles = 10
+    N_burnin = 200
+    N_sample = 10000
+
+    rng = StableRNG(SEED)
+    full_model, hier_model = GeneralisedFilters.GFTest.create_dummy_linear_gaussian_model(
+        rng, D_outer, D_inner, D_obs, T; static_arrays=false
+    )
+    _, _, ys = sample(rng, full_model, K)
+
+    # Kalman smoother
+    state, _ = GeneralisedFilters.smooth(
+        rng, full_model, KalmanSmoother(), ys; t_smooth=t_smooth
+    )
+
+    N_steps = N_burnin + N_sample
+    rbpf = RBPF(BF(N_particles; threshold=0.8), KalmanFilter())
+    ref_traj = nothing
+    predictive_likelihoods = Vector{InformationDistribution{Vector{T},Matrix{T}}}(undef, K)
+    trajectory_samples = []
+
+    for i in 1:N_steps
+        global predictive_likelihoods
+        cb = GeneralisedFilters.DenseAncestorCallback(nothing)
+
+        # Manual filtering with ancestor resampling
+        bf_state = initialise(rng, prior(hier_model), rbpf; ref_state=ref_traj)
+
+        # Post-Init callback
+        cb(hier_model, rbpf, bf_state, ys, PostInit)
+
+        for t in 1:K
+            bf_state = resample(rng, resampler(rbpf), bf_state; ref_state=ref_traj)
+
+            if !isnothing(ref_traj)
+                ancestor_weights = Vector{Float64}(undef, N_particles)
+                for j in 1:N_particles
+                    ancestor_weights[j] =
+                        bf_state.particles[j].log_w + ancestor_weight(
+                            dyn(hier_model),
+                            rbpf,
+                            t,
+                            bf_state.particles[j].state,
+                            RBState(ref_traj[t], predictive_likelihoods[t]),
+                        )
+                end
+                ancestor_idx = sample(
+                    rng, 1:N_particles, weights(softmax(ancestor_weights))
+                )
+            end
+
+            bf_state, ll = move(
+                rng, hier_model, rbpf, t, bf_state, ys[t]; ref_state=ref_traj
+            )
+
+            # Set ancestor index
+            if !isnothing(ref_traj)
+                bf_state.particles[end].ancestor = ancestor_idx
+            end
+
+            # Manually trigger callback
+            cb(hier_model, rbpf, t, bf_state, ys[t], PostUpdate)
+        end
+
+        ws = weights(bf_state)
+        sampled_idx = sample(rng, 1:N_particles, ws)
+
+        global ref_traj = GeneralisedFilters.get_ancestry(cb.container, sampled_idx)
+        if i > N_burnin
+            push!(trajectory_samples, deepcopy(ref_traj))
+        end
+        # Reference trajectory should only be nonlinear state for RBPF
+        ref_traj = getproperty.(ref_traj, :x)
+
+        pred_lik = backward_initialise(
+            rng, hier_model.inner_model.obs, BackwardInformationFilter(), K, ys[K]
+        )
+        predictive_likelihoods[K] = deepcopy(pred_lik)
+        for t in (K - 1):-1:1
+            pred_lik = backward_predict(
+                rng,
+                hier_model.inner_model.dyn,
+                BackwardInformationFilter(),
+                t,
+                pred_lik;
+                prev_outer=ref_traj[t],
+                next_outer=ref_traj[t + 1],
+            )
+            pred_lik = backward_update(
+                hier_model.inner_model.obs, BackwardInformationFilter(), t, pred_lik, ys[t]
+            )
+            predictive_likelihoods[t] = deepcopy(pred_lik)
+        end
     end
 
     # Extract inner and outer trajectories


### PR DESCRIPTION
This PR implements (and unit tests) Rao–Blackwellised ancestor sampling for the conditionally linear Gaussian state space model. Here's a quick derivation for reference. It is loosely based on [this paper](https://arxiv.org/pdf/1505.06357) but integrating over $z_{t+1}$ instead of $z_{t}$ as this fits a bit better with our interface. It's hard to say how novel this idea is. It's essentially the same computations as the reference paper (which performs RB backward simulation) but I'm not aware of any papers or code bases that use this same idea for ancestor sampling—it's really just the same collapsed Gibbs sampler but in a different order!

Let $\tilde u_{t+1:T}$ be the fixed reference future and $\left(u_{t}^{(i)}, z_t^{(i)}, w_t^{(i)}\right)_{i=1}^N$ the forward particles with their RB Kalman summaries. The general (non-Markovian form) for the ancestor weights is

$$
W_t^{(i)} \propto w_t^{(i)} \, p\left(\tilde u_{t+1:T}, y_{t+1:T} \mid u_{1:t}^{(i)}, y_{1:t}\right) \propto w_t^{(i)} \, p\left(\tilde u_{t+1} \mid u_t^{(i)}\right) \, p\left(y_{t+1:T} \mid u_{1:t}^{(i)}, y_{1:t}, \tilde u_{t+1:T}\right).
$$

We can then integrate over $z_{t+1}$ to get:

$$
W_t^{(i)} \propto w_t^{(i)} \, f\left(\tilde u_{t+1} \mid u_t^{(i)}\right)
\int p\left(y_{t+1:T} \mid z_{t+1}, \tilde u_{t+1:T}\right)
\, p\left(z_{t+1} \mid u_{1:t+1}^{(i)}, y_{1:t}\right)\,dz_{t+1},
$$

where $p\left(z_{t+1} \mid u_{1:t+1}^{(i)}, y_{1:t}\right)=\mathcal{N}\left(z_{t+1}; \bar z^{(i)}_{t+1\mid t}, \Sigma^{(i)}_{t+1\mid t}\right)$ and $p\left(y_{t+1:T} \mid z_{t+1}, \tilde u_{t+1:T}\right)$ is known as the backward predictive likelihood. Note, this is not really a density in $z_{t+1}$ but it can be interpreted as a degenerate density represented in information form:

$$
p\left(y_{t+1:T} \mid z_{t+1}, \tilde u_{t+1:T}\right)
\propto
\exp\left(-\tfrac12\left(z_{t+1}^\top \Omega_{t+1} z_{t+1} - 2 \eta_{t+1}^\top z_{t+1}\right)\right),
$$

with $\left(\Omega_{t+1}, \eta_{t+1}\right)$ produced by a backward information recursion conditioned on $\tilde u_{t+1:T}$.

I've implemented such a backward information recursion. Note this is different to a backward information filter which targets $p\left(z_t \mid y_{1:T}\right)$, differining by a factor of $p(z_t)$. In particular, this filter is initialised from the final timestep without any reference to a prior.

The integral of the predictive likelihood against the one-step ahead filtering distribution is reminiscent of the two-filter smoother formula, and admits a closed form derived in Lemma 1 of the paper. Define

$$
\Lambda_{t+1}^{(i)} = \Sigma^{(i)\,1/2}_{t+1\mid t}\,\Omega_{t+1}\,\Sigma^{(i)\,1/2}_{t+1\mid t} + I,
$$

$$
\xi_{t+1}^{(i)} =
\bar z^{(i)\,\top}_{t+1\mid t}\,\Omega_{t+1}\,\bar z^{(i)}_{t+1\mid t} - 2 \eta_{t+1}^\top \bar z^{(i)}_{t+1\mid t} - \left(\eta_{t+1} - \Omega_{t+1}\bar z^{(i)}_{t+1\mid t}\right)^\top
\Sigma^{(i)\,1/2}_{t+1\mid t}\left(\Lambda_{t+1}^{(i)}\right)^{-1}\Sigma^{(i)\,1/2}_{t+1\mid t}
\left(\eta_{t+1} - \Omega_{t+1}\bar z^{(i)}_{t+1\mid t}\right).
$$

Then

$$
W_t^{(i)} \propto w_t^{(i)} \,
f\left(\tilde u_{t+1} \mid u_t^{(i)}\right) \,
\left|\Lambda_{t+1}^{(i)}\right|^{-1/2} \,
\exp\left(-\tfrac12\,\xi_{t+1}^{(i)}\right),
$$

Therefore, when sampling the reference trajectory, we need to perform these backward information recursions to get $\left(\Omega_{t}, \eta_{t}\right)$ for $t=T,T-1,\ldots,1$ and store these for the forward pass to be used in the ancestor weights.

I haven't thought much about what the interface for this algorithm should look like. I wonder whether it is best to force the user to handle it fairly manually, similar to how is done in the unit test (with some small clean-ups).
