### PR TITLE
Remove `randcat`

### DIFF
--- a/GeneralisedFilters/src/callbacks.jl
+++ b/GeneralisedFilters/src/callbacks.jl
@@ -213,7 +213,7 @@ function get_ancestry(tree::ParticleTree{T}) where {T}
 end
 
 function rand(rng::AbstractRNG, tree::ParticleTree, weights::AbstractVector{<:Real})
-    b = randcat(rng, weights)
+    b = StatsBase.sample(rng, StatsBase.Weights(weights))
     leaf = tree.leaves[b]
 
     j = tree.parents[leaf]

--- a/GeneralisedFilters/src/resamplers.jl
+++ b/GeneralisedFilters/src/resamplers.jl
@@ -194,26 +194,6 @@ function set_ancestor(particle::Particle, ancestor::Int)
     return Particle(particle.state, log_weight(particle), ancestor)
 end
 
-## CATEGORICAL RESAMPLE ####################################################################
-
-# this is adapted from AdvancedPS
-function randcat(rng::AbstractRNG, weights::AbstractVector{WT}) where {WT<:Real}
-    # pre-calculations
-    @inbounds v = weights[1]
-    u = rand(rng, WT)
-
-    # initialize sampling algorithm
-    n = length(weights)
-    idx = 1
-
-    while (v ≤ u) && (idx < n)
-        idx += 1
-        v += weights[idx]
-    end
-
-    return idx
-end
-
 ## DOUBLE PRECISION STABLE ALGORITHMS ######################################################
 
 struct Multinomial <: AbstractResampler end


### PR DESCRIPTION
Closes #131 and replaces it with `StatsBase.sample(rng, Weights(weights))`

Both versions produce the same results with nearly identical benchmarks. The only difference being an additional step encasing weights in a StatsBase wrapper and computing the sum.

Negligible differences in performance.